### PR TITLE
Added option to disable the autotransfer function

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -7,4 +7,6 @@ preferred_ball=ITEM_POKE_BALL
 # should the bot EVER drop items (true/false)
 drop_items=true
 # Meters per second
-speed=2.778
+speed=3
+# should the bot auto transfer duplicate pokemon
+autotransfer=false

--- a/src/main/kotlin/ink/abb/pogo/scraper/Main.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Main.kt
@@ -100,6 +100,12 @@ fun main(args: Array<String>) {
         println("No speed specified, defaulting to $speed")
     }
 
+    try {
+        autotransfer = properties.getProperty("autotransfer").toBoolean()
+    } catch (e: Exception) {
+        println("No autotransfer specified, defaulting to $autotransfer")
+    }
+
     var shouldDropItems = false
     try {
         shouldDropItems = properties.getProperty("drop_items").toBoolean()
@@ -165,7 +171,7 @@ fun randomLatLng(): Double {
 }
 
 var speed = 2.778
-
+var autotransfer = false
 var walking = false
 
 val lat = AtomicDouble()
@@ -294,7 +300,7 @@ fun processMapObjects(api: PokemonGo, pokestops: MutableCollection<Pokestop>) {
     val curLevelXP = player.stats.experience - player.stats.prevLevelXp
     val ratio = DecimalFormat("##.00").format(curLevelXP.toDouble() / nextXP.toDouble() * 100.0)
     println("Profile update : ${player.stats.experience} XP on LVL ${player.stats.level}; $curLevelXP/$nextXP (${ratio}%) to LVL ${player.stats.level + 1}")
-    if (player != null) {
+    if (player != null && autotransfer) {
         // TODO: The API allows to release pokemon in batches, the app does not
         var transferredPokemon = false
         val groupedPokemon = api.pokebank.pokemons.groupBy { it.pokemonId }


### PR DESCRIPTION
Had to add this option because at the first run on my main account it transfered 3 eevees.
Maybe a system where the user can choose which pokemon can be, or not, transfered could be added.