### PR TITLE
add indication for bad encounter

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
@@ -61,7 +61,9 @@ class CatchOneNearbyPokemon : Task {
 
                     } else
                         Log.red("Capture of ${catchablePokemon.pokemonId} failed with status : ${result.status}")
-                }
+                } else {
+                    Log.red("Encounter failed with result: ${encounterResult.getStatus()}")
+                } 
             }
 
         }


### PR DESCRIPTION
This information is important; the inventory can be full, the pokemon had fled, or an error occurred.
without this, all we'll see is a repeating: 'encountered: XXXX' without knowing what caused it.