### PR TITLE
added force transfer feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,11 @@ mainClassName = 'ink.abb.pogo.scraper.MainKt'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
+configurations.all {
+    // Check for updates every build
+    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+}
+
 repositories {
     mavenCentral()
     maven { url "https://jitpack.io" }
@@ -30,7 +35,7 @@ dependencies {
 
     //compile project(':PokeGOAPI-Java')
 
-    compile 'com.github.Grover-c13:PokeGOAPI-Java:master-SNAPSHOT'
+    compile ('com.github.Grover-c13:PokeGOAPI-Java:Development-SNAPSHOT'){changing = true}
 
     compile 'com.squareup.okhttp3:okhttp:3.4.0-RC1'
 

--- a/config.properties.template
+++ b/config.properties.template
@@ -47,6 +47,9 @@ display_pokemon_catch_rewards=true
 # should the bot auto transfer duplicate pokemon
 autotransfer=false
 
+# should the bot force transfer every pokemon you catch and (IMPORTANT!) already have caught (IMPORTANT!) which do net meet CP,IV,IGNORED
+forcetransfer=false
+
 # Minimum IV percentage to keep a pokemon (to ignore IV: use -1)
 # between 0 and 100, suggested 80
 transfer_iv_threshold=80

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -61,6 +61,11 @@ class Settings(val properties: Properties) {
 
     val preferredBall = getPropertyIfSet("Preferred Ball", "preferred_ball", ItemId.ITEM_POKE_BALL, ItemId::valueOf)
     val shouldAutoTransfer = getPropertyIfSet("Autotransfer", "autotransfer", false, String::toBoolean)
+    val shouldForceTransfer = if (shouldAutoTransfer) {
+        getPropertyIfSet("Forcetransfer", "forcetransfer", false, String::toBoolean)
+    } else {
+        false
+    }
     val shouldDisplayKeepalive = getPropertyIfSet("Display Keepalive Coordinates", "display_keepalive", true, String::toBoolean)
 
     val shouldDisplayWalkingToNearestUnused = getPropertyIfSet("Display Walking to nearest Unused Pokestop", "display_walking_nearest_unused", false, String::toBoolean)

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
@@ -27,12 +27,12 @@ class ReleasePokemon : Task {
         val sortByIV = settings.sortByIV
 
         groupedPokemon.forEach {
-            var sorted = emptyList<com.pokegoapi.api.pokemon.Pokemon>()
-            if (sortByIV) {
-                sorted = it.value.sortedByDescending { it.getIv() }
-            } else {
-                sorted = it.value.sortedByDescending { it.cp }
-            }
+            var sorted = if (forceTransfer) it.value else
+                if (sortByIV) {
+                    it.value.sortedByDescending { it.getIv() }
+                } else {
+                    it.value.sortedByDescending { it.cp }
+                }
             for ((index, pokemon) in sorted.withIndex()) {
                 // don't drop favourited or nicknamed pokemon
                 val isFavourite = pokemon.nickname.isNotBlank() || pokemon.favorite

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
@@ -23,11 +23,12 @@ class ReleasePokemon : Task {
         val groupedPokemon = ctx.api.inventories.pokebank.pokemons.groupBy { it.pokemonId }
         val ignoredPokemon = settings.ignoredPokemon
         val obligatoryTransfer = settings.obligatoryTransfer
+        val forceTransfer = settings.shouldForceTransfer
         val minIVPercentage = settings.transferIVThreshold
         val minCP = settings.transferCPThreshold
 
         groupedPokemon.forEach {
-            val sorted = it.value.sortedByDescending { it.cp }
+            val sorted = if (forceTransfer) it.value else it.value.sortedByDescending { it.cp }
             for ((index, pokemon) in sorted.withIndex()) {
                 // don't drop favourited or nicknamed pokemon
                 val isFavourite = pokemon.nickname.isNotBlank() || pokemon.favorite
@@ -35,7 +36,7 @@ class ReleasePokemon : Task {
                     val iv = pokemon.getIv()
                     val ivPercentage = pokemon.getIvPercentage()
                     // never transfer highest rated Pokemon
-                    if (index > 0) {
+                    if (index > 0 || forceTransfer) {
                         // stop releasing when pokemon is set in ignoredPokemon
                         if (!ignoredPokemon.contains(pokemon.pokemonId.name)) {
                             var shouldRelease = obligatoryTransfer.contains(pokemon.pokemonId.name)

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
@@ -43,16 +43,19 @@ class ReleasePokemon : Task {
                             if (shouldRelease) {
                                 reason = "Obligatory release"
                             } else {
+                                var ivTooLow = false
+                                var cpTooLow = false
+
                                 // never transfer > min IV percentage (unless set to -1)
                                 if (ivPercentage < minIVPercentage || minIVPercentage == -1) {
-                                    shouldRelease = true
+                                    ivTooLow = true
                                 }
                                 // never transfer > min CP  (unless set to -1)
                                 if (pokemon.cp < minCP || minCP == -1) {
-                                    reason = "CP < $minCP and IV < $minIVPercentage"
-                                    // only set it to true, when it already was true, otherwise don't release
-                                    shouldRelease = shouldRelease && true
+                                    cpTooLow = true
                                 }
+                                reason = "CP < $minCP and IV < $minIVPercentage"
+                                shouldRelease = ivTooLow && cpTooLow
                             }
                             if (shouldRelease) {
                                 ctx.pokemonStats.second.andIncrement

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
@@ -37,7 +37,6 @@ class ReleasePokemon : Task {
                 // don't drop favourited or nicknamed pokemon
                 val isFavourite = pokemon.nickname.isNotBlank() || pokemon.favorite
                 if (!isFavourite) {
-                    val iv = pokemon.getIv()
                     val ivPercentage = pokemon.getIvPercentage()
                     // never transfer highest rated Pokemon
                     if (index > settings.keepPokemonAmount || forceTransfer) {


### PR DESCRIPTION
Added a force transfer option to not keep any pokemon who do not meet the requirements in IV,CP,Ignored. This also checks the pokebank, so if you have 1000 Pokemon and do not want to transfer them one by one.

Config update looks like this e.g.

```
# should the bot force transfer every pokemon you catch and (IMPORTANT!) already have caught (IMPORTANT!) which do net meet CP,IV,IGNORED
forcetransfer=true
```

PS: Don't like Kotlin man :/
