### PR TITLE
Show looted PokeStop name instead of ID

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/LootOneNearbyPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/LootOneNearbyPokestop.kt
@@ -31,7 +31,8 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
 
         if (nearbyPokestops.size > 0) {
             val closest = nearbyPokestops.first()
-            Log.normal("Looting nearby pokestop ${closest.id}")
+            val pokestopName = nearbyPokestops.first().details.name
+            Log.normal("Looting nearby pokestop \"${pokestopName}\"")
             ctx.api.setLocation(ctx.lat.get(), ctx.lng.get(), 0.0)
             val result = closest.loot()
 
@@ -40,7 +41,7 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
             }
             when (result.result) {
                 Result.SUCCESS -> {
-                    var message = "Looted pokestop ${closest.id}; +${result.experience} XP"
+                    var message = "Looted pokestop \"${pokestopName}\"; +${result.experience} XP"
                     if (settings.shouldDisplayPokestopSpinRewards)
                         message += ": ${result.itemsAwarded.groupBy { it.itemId.name }.map { "${it.value.size}x${it.key}" }}"
                     Log.green(message)
@@ -48,7 +49,7 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
                     //checkResult(result)
                 }
                 Result.INVENTORY_FULL -> {
-                    var message = "Looted pokestop ${closest.id}; +${result.experience} XP, but inventory is full"
+                    var message = "Looted pokestop \"${pokestopName}\"; +${result.experience} XP, but inventory is full"
                     if (settings.shouldDisplayPokestopSpinRewards)
                         message += ": ${result.itemsAwarded.groupBy { it.itemId.name }.map { "${it.value.size}x${it.key}" }}"
 


### PR DESCRIPTION

Before:

![before](https://cloud.githubusercontent.com/assets/1221249/17083607/01d5f02c-51af-11e6-888b-d070801e9f0d.PNG)

After:

![after](https://cloud.githubusercontent.com/assets/1221249/17083609/07e28dc2-51af-11e6-885b-60496d755ada.PNG)

I'm not much of a coder, so take it easy on me :)
