### PR TITLE
Display Pokestop Name

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -36,14 +36,18 @@ item_master_ball=50
 item_razz_berry=50
 
 ## Extra Info
-# should the bot display information of where it's walking to (true/false)
-display_walking_nearest_unused=false
-
 # should the bot display rewards pokestop (true/false)
 display_pokestop_rewards=true
 
 # should the bot display rewards when catching pokemon (true/false)
 display_pokemon_catch_rewards=true
+
+# should the bot display information of where it's walking to (true/false)
+# this will show the name of the pokestop that it's walking to and
+# replace on the loot log the pokestop id for its name
+# WARNING:  this will increase the https requests without any need. if
+#           the servers are slow it's recommended to turn off this setting
+display_pokestop_name=false
 
 ## Pokemon Transfer
 # should the bot auto transfer duplicate pokemon

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -64,7 +64,7 @@ class Settings(val properties: Properties) {
     val keepPokemonAmount = getPropertyIfSet("minimum keep pokemon amount", "keep_pokemon_amount", 1, String::toInt)
     val shouldDisplayKeepalive = getPropertyIfSet("Display Keepalive Coordinates", "display_keepalive", true, String::toBoolean)
 
-    val shouldDisplayWalkingToNearestUnused = getPropertyIfSet("Display Walking to nearest Unused Pokestop", "display_walking_nearest_unused", false, String::toBoolean)
+    val shouldDisplayPokestopName = getPropertyIfSet("Display Pokestop Name", "display_pokestop_name", false, String::toBoolean)
     val shouldDisplayPokestopSpinRewards = getPropertyIfSet("Display Pokestop Rewards", "display_pokestop_rewards", true, String::toBoolean)
     val shouldDisplayPokemonCatchRewards = getPropertyIfSet("Display Pokemon Catch Rewards", "display_pokemon_catch_rewards", true, String::toBoolean)
 

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/LootOneNearbyPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/LootOneNearbyPokestop.kt
@@ -31,7 +31,10 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
 
         if (nearbyPokestops.size > 0) {
             val closest = nearbyPokestops.first()
-            Log.normal("Looting nearby pokestop ${closest.id}")
+            var pokestopID = closest.id
+            if (settings.shouldDisplayPokestopName)
+                pokestopID = "\"${closest.details.name}\""
+            Log.normal("Looting nearby pokestop $pokestopID")
             ctx.api.setLocation(ctx.lat.get(), ctx.lng.get(), 0.0)
             val result = closest.loot()
 
@@ -40,7 +43,7 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
             }
             when (result.result) {
                 Result.SUCCESS -> {
-                    var message = "Looted pokestop ${closest.id}; +${result.experience} XP"
+                    var message = "Looted pokestop $pokestopID; +${result.experience} XP"
                     if (settings.shouldDisplayPokestopSpinRewards)
                         message += ": ${result.itemsAwarded.groupBy { it.itemId.name }.map { "${it.value.size}x${it.key}" }}"
                     Log.green(message)
@@ -48,7 +51,7 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
                     //checkResult(result)
                 }
                 Result.INVENTORY_FULL -> {
-                    var message = "Looted pokestop ${closest.id}; +${result.experience} XP, but inventory is full"
+                    var message = "Looted pokestop $pokestopID; +${result.experience} XP, but inventory is full"
                     if (settings.shouldDisplayPokestopSpinRewards)
                         message += ": ${result.itemsAwarded.groupBy { it.itemId.name }.map { "${it.value.size}x${it.key}" }}"
 

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
@@ -34,7 +34,7 @@ class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts
         }
 
         if (nearestUnused.size > 0) {
-            if (settings.shouldDisplayWalkingToNearestUnused)
+            if (settings.shouldDisplayPokestopName)
                 Log.normal("Walking to pokestop \"${nearestUnused.first().details.name}\"")
             walk(ctx, S2LatLng.fromDegrees(nearestUnused.first().latitude, nearestUnused.first().longitude), settings.speed)
         }


### PR DESCRIPTION
**Fixed issue:** #192

**Changes made:**

* Renamed config display_walking_nearest_unused to display_pokestop_name
* This config now replaces the id on pokestop loot log to its name

As the title implies, this adds the option to display the pokestop name instead of its id in the log. 
Joined log of walking to nearest unused pokestop in the same setting.