### PR TITLE
Added settings toggle for sorting by IV instead of CP

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -56,6 +56,9 @@ autotransfer=false
 # minimum amount of pokemon type to keep
 keep_pokemon_amount=1
 
+# Sort by IV first instead of CP
+sort_by_iv=false
+
 # Minimum IV percentage to keep a pokemon (to ignore IV: use -1)
 # between 0 and 100, suggested 80
 transfer_iv_threshold=80

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -70,6 +70,8 @@ class Settings(val properties: Properties) {
 
     val walkOnly = getPropertyIfSet("Only walk to hatch eggs", "walk_only", false, String::toBoolean)
 
+    val sortByIV = getPropertyIfSet("Sort by IV first instead of CP", "sort_by_iv", false, String::toBoolean)
+
     val transferCPThreshold = getPropertyIfSet("Minimum CP to keep a pokemon", "transfer_cp_threshold", 400, String::toInt)
 
     val transferIVThreshold = getPropertyIfSet("Minimum IV percentage to keep a pokemon", "transfer_iv_threshold", 80, String::toInt)

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
@@ -25,9 +25,15 @@ class ReleasePokemon : Task {
         val obligatoryTransfer = settings.obligatoryTransfer
         val minIVPercentage = settings.transferIVThreshold
         val minCP = settings.transferCPThreshold
+        val sortByIV = settings.sortByIV
 
         groupedPokemon.forEach {
-            val sorted = it.value.sortedByDescending { it.cp }
+            var sorted = emptyList<com.pokegoapi.api.pokemon.Pokemon>()
+            if (sortByIV) {
+                sorted = it.value.sortedByDescending { it.getIv() }
+            } else {
+                sorted = it.value.sortedByDescending { it.cp }
+            }
             for ((index, pokemon) in sorted.withIndex()) {
                 // don't drop favourited or nicknamed pokemon
                 val isFavourite = pokemon.nickname.isNotBlank() || pokemon.favorite


### PR DESCRIPTION
Even with transfer_iv_threshold and transfer_cp_threshold set to -1, transfer will still favour the pokemon with the highest CP even if it has an IV of 1%. I propose the setting sort_by_iv to allow users to keep the highest IV pokemon regardless of CP.