### PR TITLE
Fixed IV typo on the release log

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
@@ -66,7 +66,7 @@ class ReleasePokemon : Task {
                             if (shouldRelease) {
                                 ctx.pokemonStats.second.andIncrement
                                 Log.yellow("Going to transfer ${pokemon.pokemonId.name} with " +
-                                        "CP ${pokemon.cp} and IV $iv%; reason: $reason")
+                                        "CP ${pokemon.cp} and IV $ivPercentage%; reason: $reason")
                                 pokemon.transferPokemon()
                             }
                         }


### PR DESCRIPTION
**Fixed issue:** IV info on release

**Changes made:**

* Changed $iv to $ivPercentage

The log was printing a % character while using the sum of the individual values of the pokemons instead of the perfection percentage.