### PR TITLE
Fixed problem with token writing

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -125,15 +125,18 @@ class Settings(val properties: Properties) {
     fun writeToken(propertyFile: String) {
         val file = BufferedReader(FileReader(propertyFile))
         var propertiesText = String()
-
+        var foundToken = false
         file.lines().forEach {
             if (it != null && it.startsWith("token")) {
                 propertiesText += "token=${this.properties.getProperty("token")}\n"
+                foundToken = true
             } else if (it != null) {
                 propertiesText += "$it\n"
             }
         }
-
+        if (!foundToken){
+            propertiesText += "token=${this.properties.getProperty("token")}\n"
+        }
         file.close()
 
         val out = FileOutputStream(propertyFile)


### PR DESCRIPTION
It wouldn't write the token if there was no line in the config file starting with "token"