### PR TITLE
Remove internal pokestop blacklist in favor of the protobuff blacklist.

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/LootOneNearbyPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/LootOneNearbyPokestop.kt
@@ -21,13 +21,13 @@ import ink.abb.pogo.scraper.util.map.canLoot
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts: HashMap<String, Long>) : Task {
+class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>) : Task {
 
     private var pauseDuration = 1L
 
     override fun run(bot: Bot, ctx: Context, settings: Settings) {
         val nearbyPokestops = sortedPokestops.filter {
-            it.canLoot(lootTimeouts = lootTimeouts)
+            it.canLoot()
         }
 
         if (nearbyPokestops.isNotEmpty()) {
@@ -48,7 +48,6 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
                     if (settings.shouldDisplayPokestopSpinRewards)
                         message += ": ${result.itemsAwarded.groupBy { it.itemId.name }.map { "${it.value.size}x${it.key}" }}"
                     Log.green(message)
-                    lootTimeouts.put(closest.id, closest.cooldownCompleteTimestampMs)
                     //checkResult(result)
                 }
                 Result.INVENTORY_FULL -> {
@@ -57,7 +56,6 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
                         message += ": ${result.itemsAwarded.groupBy { it.itemId.name }.map { "${it.value.size}x${it.key}" }}"
 
                     Log.red(message)
-                    lootTimeouts.put(closest.id, closest.cooldownCompleteTimestampMs)
                 }
                 Result.OUT_OF_RANGE -> {
                     val location = S2LatLng.fromDegrees(closest.latitude, closest.longitude)
@@ -67,8 +65,7 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
                 }
                 Result.IN_COOLDOWN_PERIOD -> {
                     val cooldownPeriod = 5
-                    lootTimeouts.put(closest.id, System.currentTimeMillis() + cooldownPeriod * 60 * 1000)
-                    Log.red("Pokestop still in cooldown mode; blacklisting for $cooldownPeriod minutes")
+                    Log.red("Pokestop still in cooldown mode")
                 }
                 else -> Log.yellow(result.result.toString())
             }

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/LootOneNearbyPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/LootOneNearbyPokestop.kt
@@ -17,8 +17,6 @@ import ink.abb.pogo.scraper.Context
 import ink.abb.pogo.scraper.Settings
 import ink.abb.pogo.scraper.Task
 import ink.abb.pogo.scraper.util.Log
-import ink.abb.pogo.scraper.util.map.canLoot
-import java.util.*
 import java.util.concurrent.TimeUnit
 
 class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>) : Task {
@@ -64,7 +62,6 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>) : Task {
                     Log.red("Pokestop out of range; distance: $distance")
                 }
                 Result.IN_COOLDOWN_PERIOD -> {
-                    val cooldownPeriod = 5
                     Log.red("Pokestop still in cooldown mode")
                 }
                 else -> Log.yellow(result.result.toString())

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ProcessPokestops.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ProcessPokestops.kt
@@ -23,8 +23,6 @@ import java.util.*
  */
 class ProcessPokestops(val pokestops: MutableCollection<Pokestop>) : Task {
 
-    private val lootTimeouts = HashMap<String, Long>()
-
     override fun run(bot: Bot, ctx: Context, settings: Settings) {
         val sortedPokestops = pokestops.sortedWith(Comparator { a, b ->
             val locationA = S2LatLng.fromDegrees(a.latitude, a.longitude)
@@ -36,10 +34,10 @@ class ProcessPokestops(val pokestops: MutableCollection<Pokestop>) : Task {
         })
 
         if (!settings.walkOnly) {
-            val loot = LootOneNearbyPokestop(sortedPokestops, lootTimeouts)
+            val loot = LootOneNearbyPokestop(sortedPokestops)
             bot.task(loot)
         }
-        val walk = WalkToUnusedPokestop(sortedPokestops, lootTimeouts)
+        val walk = WalkToUnusedPokestop(sortedPokestops)
 
         bot.task(walk)
     }

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
@@ -15,7 +15,6 @@ import ink.abb.pogo.scraper.Context
 import ink.abb.pogo.scraper.Settings
 import ink.abb.pogo.scraper.Task
 import ink.abb.pogo.scraper.util.Log
-import ink.abb.pogo.scraper.util.map.canLoot
 import kotlin.concurrent.fixedRateTimer
 
 class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>) : Task {

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
@@ -18,7 +18,7 @@ import ink.abb.pogo.scraper.util.Log
 import ink.abb.pogo.scraper.util.map.canLoot
 import kotlin.concurrent.fixedRateTimer
 
-class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts: Map<String, Long>) : Task {
+class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>) : Task {
 
     override fun run(bot: Bot, ctx: Context, settings: Settings) {
         // don't run away when there are still Pokemon around
@@ -31,7 +31,7 @@ class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts
         }
 
         val nearestUnused = sortedPokestops.filter {
-            it.canLoot(ignoreDistance = true, lootTimeouts = lootTimeouts)
+            it.canLoot(true)
         }
 
         if (nearestUnused.isNotEmpty()) {

--- a/src/main/kotlin/ink/abb/pogo/scraper/util/map/Pokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/util/map/Pokestop.kt
@@ -10,7 +10,3 @@ package ink.abb.pogo.scraper.util.map
 
 import com.pokegoapi.api.map.fort.Pokestop
 
-fun Pokestop.canLoot(ignoreDistance: Boolean = false, lootTimeouts: Map<String, Long>): Boolean {
-    val canLoot = lootTimeouts.getOrElse(id, { 0 }) < System.currentTimeMillis()
-    return (ignoreDistance || inRange()) && canLoot
-}


### PR DESCRIPTION
Why were we using a custom lootTimeout instead of the timeout provided by the server?  With the custom timeout, the bot would try to loot all the pokestops it had the run before (if restarted within 5 mins from the same location).  Using the server timeouts, it works just fine.

