### PR TITLE
Added randomness to next pokestop selection

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
@@ -35,9 +35,13 @@ class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts
         }
 
         if (nearestUnused.isNotEmpty()) {
+            // Select random pokestop from the 5 nearest while taking the distance into account
+            val chosenPokestop = selectRandom(nearestUnused.take(5), ctx)            
+
             if (settings.shouldDisplayPokestopName)
-                Log.normal("Walking to pokestop \"${nearestUnused.first().details.name}\"")
-            walk(ctx, S2LatLng.fromDegrees(nearestUnused.first().latitude, nearestUnused.first().longitude), settings.speed)
+                Log.normal("Walking to pokestop \"${chosenPokestop.details.name}\"")
+
+            walk(ctx, S2LatLng.fromDegrees(chosenPokestop.latitude, chosenPokestop.longitude), settings.speed)
         }
     }
 
@@ -72,5 +76,38 @@ class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts
                 cancel()
             }
         })
+    }
+
+    private fun selectRandom(pokestops: List<Pokestop>, ctx: Context) : Pokestop {
+        // Select random pokestop while taking the distance into account
+        // E.g. pokestop is closer to the user -> higher probabilty to be chosen
+
+        if (pokestops.size < 2) 
+            return pokestops.first()
+
+        val currentPosition = S2LatLng.fromDegrees(ctx.lat.get(), ctx.lng.get())
+
+        val distances = pokestops.map {
+            val end = S2LatLng.fromDegrees(it.latitude, it.longitude)
+            currentPosition.getEarthDistance(end)
+        }
+        val totalDistance = distances.sum()
+
+        // Get random value between 0 and 1
+        val random = Math.random()
+        var cumulativeProbability = 0.0;
+      
+        for ((index, pokestop) in pokestops.withIndex()) {
+            // Calculate probabilty proportional to the closeness
+            val probability = (1 - distances[index]/totalDistance) / (pokestops.size - 1)         
+
+            cumulativeProbability += probability
+            if (random <= cumulativeProbability) {
+                return pokestop
+            }
+        }
+
+        // should not happen
+        return pokestops.first()
     }
 }


### PR DESCRIPTION
**Changes made:**

* Made pokestop selection non deterministic by choosing a random pokestop out of the nearest five while still taking the distance into account

Background: I noticed that my bot was sometimes stuck in a loop and always visited the same 10-20 pokestops (after they were out of cooldown). This resulted in fewer pokemons caught since they did not respawn in the meantime.
With this change the bot will not always select the nearest pokestop to go to. Instead the next pokestop is chosen randomly from the 5 nearest ones. To prevent cases where the bot selects a pokestop which is far away, the probability is not the same for each pokestop. It is proportional to the distance meaning that a pokestop which is very close will have a higher probabilty to be chosen (but it is not always chosen).
This will introduce some randomness but still maximize the XP gained.
