### PR TITLE
Allow for graceful bot shutdown.

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/Main.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Main.kt
@@ -18,6 +18,7 @@ import okhttp3.OkHttpClient
 import java.io.FileInputStream
 import java.util.*
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 
 fun main(args: Array<String>) {
     val builder = OkHttpClient.Builder()
@@ -77,5 +78,8 @@ fun main(args: Array<String>) {
     }
     println(".")
 
-    Bot(api, settings).run()
+    val bot = Bot(api, settings)
+    Runtime.getRuntime().addShutdownHook(thread(start = false) { bot.stop() })
+
+    bot.start()
 }

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
@@ -37,11 +37,11 @@ class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts
         if (nearestUnused.isNotEmpty()) {
             if (settings.shouldDisplayPokestopName)
                 Log.normal("Walking to pokestop \"${nearestUnused.first().details.name}\"")
-            walk(ctx, S2LatLng.fromDegrees(nearestUnused.first().latitude, nearestUnused.first().longitude), settings.speed)
+            walk(bot, ctx, S2LatLng.fromDegrees(nearestUnused.first().latitude, nearestUnused.first().longitude), settings.speed)
         }
     }
 
-    fun walk(ctx: Context, end: S2LatLng, speed: Double) {
+    fun walk(bot: Bot, ctx: Context, end: S2LatLng, speed: Double) {
         val start = S2LatLng.fromDegrees(ctx.lat.get(), ctx.lng.get())
         val diff = end.sub(start)
         val distance = start.getEarthDistance(end)
@@ -62,7 +62,7 @@ class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts
         Log.normal("Walking to ${end.toStringDegrees()} in $stepsRequired steps.")
         var remainingSteps = stepsRequired
 
-        fixedRateTimer("Walk", false, 0, timeout, action = {
+        bot.runLoop(timeout, "WalkingLoop") { cancel ->
             ctx.lat.addAndGet(deltaLat)
             ctx.lng.addAndGet(deltaLng)
             remainingSteps--
@@ -71,6 +71,6 @@ class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts
                 ctx.walking.set(false)
                 cancel()
             }
-        })
+        }
     }
 }


### PR DESCRIPTION
Currently, when killing the bot (SIGINT), the bot dies immediately, regardless of whether it was executing an API call.  This change allows the bot loops to finish before the bot is killed.

Consequently, there's another side effect - the bot loops are now synchronous.  This is also an improvement, as you don't ever want your bot loop running twice at the same time.

With this change, the loop allocate 5 seconds for the bot loop, and depending on how long the actions take will only "sleep" for the remaining time after the tasks are done.  I wasn't sure if that would be preferable to always waiting 5 seconds after tasks were complete.
