### PR TITLE
Adds Configuration for randomness to next pokestop selection

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -17,6 +17,10 @@ desired_catch_probability=0.4
 # set to -1 to not attempt catching at all
 desired_catch_probability_unwanted=0.0
 
+# number of nearest unused pokestops to randomly select
+# the next pokestop from (1/infinit)
+randomNextPokestop=1
+
 ## Walking
 # Meters per second
 speed=2.778

--- a/config.properties.template
+++ b/config.properties.template
@@ -18,8 +18,8 @@ desired_catch_probability=0.4
 desired_catch_probability_unwanted=0.0
 
 # number of nearest unused pokestops to randomly select
-# the next pokestop from (1/infinit)
-randomNextPokestop=1
+# the next pokestop from (1/infinite)
+random_next_pokestop_selection=5
 
 ## Walking
 # Meters per second

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -63,6 +63,8 @@ class Settings(val properties: Properties) {
         )
     }
 
+    val randomNextPokestop = getPropertyIfSet("Number of pokestops to select next", "randomNextPokestop", 5, String::toInt)
+
     val desiredCatchProbability = getPropertyIfSet("Desired chance to catch a Pokemon with 1 ball", "desired_catch_probability", 0.4, String::toDouble)
     val desiredCatchProbabilityUnwanted = getPropertyIfSet("Desired probability to catch unwanted Pokemon (obligatory_transfer; low IV; low CP)", "desired_catch_probability_unwanted", 0.0, String::toDouble)
     val shouldAutoTransfer = getPropertyIfSet("Autotransfer", "autotransfer", false, String::toBoolean)

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -63,7 +63,7 @@ class Settings(val properties: Properties) {
         )
     }
 
-    val randomNextPokestop = getPropertyIfSet("Number of pokestops to select next", "randomNextPokestop", 5, String::toInt)
+    val randomNextPokestop = getPropertyIfSet("Number of pokestops to select next", "random_next_pokestop_selection", 5, String::toInt)
 
     val desiredCatchProbability = getPropertyIfSet("Desired chance to catch a Pokemon with 1 ball", "desired_catch_probability", 0.4, String::toDouble)
     val desiredCatchProbabilityUnwanted = getPropertyIfSet("Desired probability to catch unwanted Pokemon (obligatory_transfer; low IV; low CP)", "desired_catch_probability_unwanted", 0.0, String::toDouble)

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
@@ -35,7 +35,7 @@ class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts
 
         if (nearestUnused.isNotEmpty()) {
             // Select random pokestop from the 5 nearest while taking the distance into account
-            val chosenPokestop = selectRandom(nearestUnused.take(5), ctx)
+            val chosenPokestop = selectRandom(nearestUnused.take(settings.randomNextPokestop), ctx)
 
             if (settings.shouldDisplayPokestopName)
                 Log.normal("Walking to pokestop \"${chosenPokestop.details.name}\"")


### PR DESCRIPTION
**Expands issue:** #334

**Changes made:**

* Added `randomNextPokestop` to config file

Now you can adjust the randomness of your next pokestop selection (taking into account the nearest ones). If you don't want randomness just put 1 in the field.