### PR TITLE
Fixing bot not walking, only getting map

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToUnusedPokestop.kt
@@ -22,7 +22,7 @@ class WalkToUnusedPokestop(val sortedPokestops: List<Pokestop>, val lootTimeouts
     override fun run(bot: Bot, ctx: Context, settings: Settings) {
         // don't run away when there are still Pokemon around
         val pokemonCount = ctx.api.map?.catchablePokemon?.filter { !ctx.blacklistedEncounters.contains(it.encounterId) }?.size
-        if (pokemonCount != null && pokemonCount > 0) {
+        if (pokemonCount != null && pokemonCount > 0 && settings.shouldCatchPokemons) {
             return
         }
         if (!ctx.walking.compareAndSet(false, true)) {


### PR DESCRIPTION
**Fixed issue:** #461

**Changes made:**

* Added check for `shouldCatchPokemons` before redirecting to pokemon nearby.