### PR TITLE
Set a maximum number of each Pokémon you want to keep.

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -76,6 +76,9 @@ autotransfer=true
 # minimum amount of pokemon type to keep
 keep_pokemon_amount=1
 
+# maximum amount of pokemon type to keep (-1 to keep all)
+max_pokemon_amount=-1
+
 # Sort by IV first instead of CP
 sort_by_iv=false
 

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -69,6 +69,7 @@ class Settings(val properties: Properties) {
     val desiredCatchProbabilityUnwanted = getPropertyIfSet("Desired probability to catch unwanted Pokemon (obligatory_transfer; low IV; low CP)", "desired_catch_probability_unwanted", 0.0, String::toDouble)
     val shouldAutoTransfer = getPropertyIfSet("Autotransfer", "autotransfer", false, String::toBoolean)
     val keepPokemonAmount = getPropertyIfSet("minimum keep pokemon amount", "keep_pokemon_amount", 1, String::toInt)
+    val maxPokemonAmount = getPropertyIfSet("maximum keep pokemon amount", "max_pokemon_amount", -1, String::toInt)
     val shouldDisplayKeepalive = getPropertyIfSet("Display Keepalive Coordinates", "display_keepalive", true, String::toBoolean)
 
     val shouldDisplayPokestopName = getPropertyIfSet("Display Pokestop Name", "display_pokestop_name", false, String::toBoolean)

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
@@ -70,11 +70,8 @@ class ReleasePokemon : Task {
             return false
         }
         val name = pokemon.pokemonId.name
-        if (!pokemonCounts.containsKey(name)) {
-            pokemonCounts.set(name, 0)
-        }
-        val count = pokemonCounts.get(name)!! + 1
-        pokemonCounts.set(name, count)
+        val count = pokemonCounts.getOrElse(name, { 0 }) + 1
+        pokemonCounts.put(name, count)
         return (count > max)
     }
 }


### PR DESCRIPTION
I noticed a problem where if I find too many of the same type of powerful creature, my bag fills up with them and it's a _huge_ pain to go manually delete them all. (In NYC I captured over 100 Pinsirs that were too strong to be dropped.)

**Changes made:**

* Added a setting for `max_pokemon_amount`
* Deletes any Pokémon where you have too many of the same type
* Defaults to unchanged behavior (doesn't delete regardless of how many of the same type you have)
