### PR TITLE
Make the socket listen on 0.0.0.0

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/gui/SocketServer.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/gui/SocketServer.kt
@@ -28,7 +28,6 @@ class SocketServer {
 
     fun start(ctx: Context, port: Int) {
         val config = Configuration()
-        config.hostname = "localhost"
         config.port = port
 
         this.ctx = ctx


### PR DESCRIPTION
**Fixed issue:** Can't use WebGUI when not running from localhost.

**Changes made:**

* Bound to 0.0.0.0 instead of 127.0.0.1

This removes the socket listening limitation. Otherwise you will only be able to run this interface when running the bot on localhost.