### PR TITLE
Separate settings from config.properties data and fix google login without username/password.

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -28,7 +28,7 @@ class SettingsParser(val properties: Properties) {
             startingLongitude = getPropertyOrDie("Starting Longitude", "longitude", String::toDouble),
 
             credentials = if (properties.getProperty("username", "").isEmpty()) {
-                GoogleCredentials(properties.getProperty("token"))
+                GoogleCredentials(properties.getProperty("token", ""))
             } else if(properties.getProperty("username", "").contains("@")) {
                 GoogleAutoCredentials(properties.getProperty("username"), getPasswordProperty())
             } else {

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -20,23 +20,23 @@ import java.util.Properties
 
 
 class SettingsParser(val properties: Properties) {
-fun createSettingsFromProperties(): Settings {
-    return Settings(
-    profileUpdateTimer = getPropertyIfSet("Set Profile Update Timer", "profile_update_timer", 60, String::toLong),
+    fun createSettingsFromProperties(): Settings {
+        return Settings(
+            profileUpdateTimer = getPropertyIfSet("Set Profile Update Timer", "profile_update_timer", 60, String::toLong),
 
-    startingLatitude = getPropertyOrDie("Starting Latitude", "latitude", String::toDouble),
-    startingLongitude = getPropertyOrDie("Starting Longitude", "longitude", String::toDouble),
+            startingLatitude = getPropertyOrDie("Starting Latitude", "latitude", String::toDouble),
+            startingLongitude = getPropertyOrDie("Starting Longitude", "longitude", String::toDouble),
 
-    credentials = if(properties.getProperty("username", "").isEmpty() || properties.getProperty("username", "").contains("@")) {
-        GoogleCredentials(properties.getProperty("token"))
-    } else {
-        PtcCredentials(properties.getProperty("username"), if (properties.containsKey("password")) properties.getProperty("password") else String(Base64.getDecoder().decode(properties.getProperty("base64_password", ""))))
-    },
+            credentials = if (properties.getProperty("username", "").isEmpty() || properties.getProperty("username", "").contains("@")) {
+                GoogleCredentials(properties.getProperty("token"))
+            } else {
+                PtcCredentials(properties.getProperty("username"), if (properties.containsKey("password")) properties.getProperty("password") else String(Base64.getDecoder().decode(properties.getProperty("base64_password", ""))))
+            },
 
-    speed = getPropertyIfSet("Speed", "speed", 2.778, String::toDouble),
-    shouldDropItems = getPropertyIfSet("Item Drop", "drop_items", false, String::toBoolean),
+            speed = getPropertyIfSet("Speed", "speed", 2.778, String::toDouble),
+            shouldDropItems = getPropertyIfSet("Item Drop", "drop_items", false, String::toBoolean),
 
-    uselessItems = mapOf(
+            uselessItems = mapOf(
                 Pair(ItemId.ITEM_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_REVIVE", "item_revive", 20, String::toInt)),
                 Pair(ItemId.ITEM_MAX_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_MAX_REVIVE", "item_max_revive", 10, String::toInt)),
                 Pair(ItemId.ITEM_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_POTION", "item_potion", 0, String::toInt)),
@@ -48,47 +48,47 @@ fun createSettingsFromProperties(): Settings {
                 Pair(ItemId.ITEM_ULTRA_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_ULTRA_BALL", "item_ultra_ball", 50, String::toInt)),
                 Pair(ItemId.ITEM_MASTER_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_MASTER_BALL", "item_master_ball", 10, String::toInt)),
                 Pair(ItemId.ITEM_RAZZ_BERRY, getPropertyIfSet("Max number of items to keep from type ITEM_RAZZ_BERRY", "item_razz_berry", 50, String::toInt))
-        ),
+            ),
 
-    randomNextPokestop = getPropertyIfSet("Number of pokestops to select next", "random_next_pokestop_selection", 5, String::toInt),
+            randomNextPokestop = getPropertyIfSet("Number of pokestops to select next", "random_next_pokestop_selection", 5, String::toInt),
 
-    desiredCatchProbability = getPropertyIfSet("Desired chance to catch a Pokemon with 1 ball", "desired_catch_probability", 0.4, String::toDouble),
-    desiredCatchProbabilityUnwanted = getPropertyIfSet("Desired probability to catch unwanted Pokemon (obligatory_transfer; low IV; low CP)", "desired_catch_probability_unwanted", 0.0, String::toDouble),
-    shouldAutoTransfer = getPropertyIfSet("Autotransfer", "autotransfer", false, String::toBoolean),
-    keepPokemonAmount = getPropertyIfSet("minimum keep pokemon amount", "keep_pokemon_amount", 1, String::toInt),
-    maxPokemonAmount = getPropertyIfSet("maximum keep pokemon amount", "max_pokemon_amount", -1, String::toInt),
-    shouldDisplayKeepalive = getPropertyIfSet("Display Keepalive Coordinates", "display_keepalive", true, String::toBoolean),
+            desiredCatchProbability = getPropertyIfSet("Desired chance to catch a Pokemon with 1 ball", "desired_catch_probability", 0.4, String::toDouble),
+            desiredCatchProbabilityUnwanted = getPropertyIfSet("Desired probability to catch unwanted Pokemon (obligatory_transfer; low IV; low CP)", "desired_catch_probability_unwanted", 0.0, String::toDouble),
+            shouldAutoTransfer = getPropertyIfSet("Autotransfer", "autotransfer", false, String::toBoolean),
+            keepPokemonAmount = getPropertyIfSet("minimum keep pokemon amount", "keep_pokemon_amount", 1, String::toInt),
+            maxPokemonAmount = getPropertyIfSet("maximum keep pokemon amount", "max_pokemon_amount", -1, String::toInt),
+            shouldDisplayKeepalive = getPropertyIfSet("Display Keepalive Coordinates", "display_keepalive", true, String::toBoolean),
 
-    shouldDisplayPokestopName = getPropertyIfSet("Display Pokestop Name", "display_pokestop_name", false, String::toBoolean),
-    shouldDisplayPokestopSpinRewards = getPropertyIfSet("Display Pokestop Rewards", "display_pokestop_rewards", true, String::toBoolean),
-    shouldDisplayPokemonCatchRewards = getPropertyIfSet("Display Pokemon Catch Rewards", "display_pokemon_catch_rewards", true, String::toBoolean),
+            shouldDisplayPokestopName = getPropertyIfSet("Display Pokestop Name", "display_pokestop_name", false, String::toBoolean),
+            shouldDisplayPokestopSpinRewards = getPropertyIfSet("Display Pokestop Rewards", "display_pokestop_rewards", true, String::toBoolean),
+            shouldDisplayPokemonCatchRewards = getPropertyIfSet("Display Pokemon Catch Rewards", "display_pokemon_catch_rewards", true, String::toBoolean),
 
-    shouldLootPokestop = getPropertyIfSet("Loot Pokestops", "loot_pokestop", true, String::toBoolean),
-    shouldCatchPokemons = getPropertyIfSet("Catch Pokemons", "catch_pokemon", true, String::toBoolean),
-    shouldAutoFillIncubators = getPropertyIfSet("Auto Fill Incubators", "auto_fill_incubator", true, String::toBoolean),
+            shouldLootPokestop = getPropertyIfSet("Loot Pokestops", "loot_pokestop", true, String::toBoolean),
+            shouldCatchPokemons = getPropertyIfSet("Catch Pokemons", "catch_pokemon", true, String::toBoolean),
+            shouldAutoFillIncubators = getPropertyIfSet("Auto Fill Incubators", "auto_fill_incubator", true, String::toBoolean),
 
-    sortByIV = getPropertyIfSet("Sort by IV first instead of CP", "sort_by_iv", false, String::toBoolean),
+            sortByIV = getPropertyIfSet("Sort by IV first instead of CP", "sort_by_iv", false, String::toBoolean),
 
-    alwaysCurve = getPropertyIfSet("Always throw curveballs", "always_curve", false, String::toBoolean),
+            alwaysCurve = getPropertyIfSet("Always throw curveballs", "always_curve", false, String::toBoolean),
 
-    neverUseBerries = getPropertyIfSet("Never use berries", "never_use_berries", true, String::toBoolean),
+            neverUseBerries = getPropertyIfSet("Never use berries", "never_use_berries", true, String::toBoolean),
 
-    allowLeaveStartArea = getPropertyIfSet("Allow leaving the starting area", "allow_leave_start_area", false, String::toBoolean),
+            allowLeaveStartArea = getPropertyIfSet("Allow leaving the starting area", "allow_leave_start_area", false, String::toBoolean),
 
-    spawnRadius = getPropertyIfSet("Max distance from starting point the bot should ever go", "spawn_radius", -1, String::toInt),
+            spawnRadius = getPropertyIfSet("Max distance from starting point the bot should ever go", "spawn_radius", -1, String::toInt),
 
-    transferCPThreshold = getPropertyIfSet("Minimum CP to keep a pokemon", "transfer_cp_threshold", 400, String::toInt),
+            transferCPThreshold = getPropertyIfSet("Minimum CP to keep a pokemon", "transfer_cp_threshold", 400, String::toInt),
 
-    transferIVThreshold = getPropertyIfSet("Minimum IV percentage to keep a pokemon", "transfer_iv_threshold", 80, String::toInt),
+            transferIVThreshold = getPropertyIfSet("Minimum IV percentage to keep a pokemon", "transfer_iv_threshold", 80, String::toInt),
 
-    ignoredPokemon = getPropertyIfSet("Never transfer these Pokemon", "ignored_pokemon", "EEVEE,MEWTWO,CHARMANDER", String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
+            ignoredPokemon = getPropertyIfSet("Never transfer these Pokemon", "ignored_pokemon", "EEVEE,MEWTWO,CHARMANDER", String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
 
-    obligatoryTransfer = getPropertyIfSet("list of pokemon you always want to transfer regardless of CP", "obligatory_transfer", "DODUO,RATTATA,CATERPIE,PIDGEY", String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
+            obligatoryTransfer = getPropertyIfSet("list of pokemon you always want to transfer regardless of CP", "obligatory_transfer", "DODUO,RATTATA,CATERPIE,PIDGEY", String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
 
-    guiPort = getPropertyIfSet("Port where the webserver should listen", "gui_port", 8000, String::toInt),
-    guiPortSocket = getPropertyIfSet("Port where the socketserver should listen", "gui_port_socket", 8001, String::toInt)
-    )
-}
+            guiPort = getPropertyIfSet("Port where the webserver should listen", "gui_port", 8000, String::toInt),
+            guiPortSocket = getPropertyIfSet("Port where the socketserver should listen", "gui_port_socket", 8001, String::toInt)
+        )
+    }
 
     fun <T> getPropertyOrDie(description: String, property: String, conversion: (String) -> T): T {
         val settingString = "$description setting (\"$property\")"
@@ -212,9 +212,9 @@ data class Settings(
 
 interface Credentials
 
-data class GoogleCredentials(var token: String = ""): Credentials
+data class GoogleCredentials(var token: String = "") : Credentials
 
 data class PtcCredentials(
     val username: String = "",
     val password: String = ""
-): Credentials
+) : Credentials

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -8,38 +8,35 @@
 
 package ink.abb.pogo.scraper
 
+import POGOProtos.Enums.PokemonIdOuterClass.PokemonId
 import POGOProtos.Inventory.Item.ItemIdOuterClass.ItemId
-import com.pokegoapi.api.inventory.Pokeball
 import com.pokegoapi.google.common.geometry.S2LatLng
 import ink.abb.pogo.scraper.util.Log
 import java.io.BufferedReader
 import java.io.FileOutputStream
 import java.io.FileReader
-import java.util.*
+import java.util.Base64
+import java.util.Properties
 
-class Settings(val properties: Properties) {
 
-    val profileUpdateTimer = getPropertyIfSet("Set Profile Update Timer", "profile_update_timer", 60, String::toLong)
+class SettingsParser(val properties: Properties) {
+fun createSettingsFromProperties(): Settings {
+    return Settings(
+    profileUpdateTimer = getPropertyIfSet("Set Profile Update Timer", "profile_update_timer", 60, String::toLong),
 
-    val pokeballItems = mapOf(Pair(ItemId.ITEM_POKE_BALL, Pokeball.POKEBALL),
-            Pair(ItemId.ITEM_ULTRA_BALL, Pokeball.ULTRABALL),
-            Pair(ItemId.ITEM_GREAT_BALL, Pokeball.GREATBALL),
-            Pair(ItemId.ITEM_MASTER_BALL, Pokeball.MASTERBALL))
+    startingLatitude = getPropertyOrDie("Starting Latitude", "latitude", String::toDouble),
+    startingLongitude = getPropertyOrDie("Starting Longitude", "longitude", String::toDouble),
 
-    val startingLatitude = getPropertyOrDie("Starting Latitude", "latitude", String::toDouble)
-    val startingLongitude = getPropertyOrDie("Starting Longitude", "longitude", String::toDouble)
+    credentials = if(properties.getProperty("username", "").isEmpty() || properties.getProperty("username", "").contains("@")) {
+        GoogleCredentials(properties.getProperty("token"))
+    } else {
+        PtcCredentials(properties.getProperty("username"), if (properties.containsKey("password")) properties.getProperty("password") else String(Base64.getDecoder().decode(properties.getProperty("base64_password", ""))))
+    },
 
-    val startingLocation = S2LatLng.fromDegrees(startingLatitude, startingLongitude)
+    speed = getPropertyIfSet("Speed", "speed", 2.778, String::toDouble),
+    shouldDropItems = getPropertyIfSet("Item Drop", "drop_items", false, String::toBoolean),
 
-    val username = properties.getProperty("username")
-    val password = if (properties.containsKey("password")) properties.getProperty("password") else String(Base64.getDecoder().decode(properties.getProperty("base64_password", "")))
-    val token = { properties.getProperty("token", "") }
-
-    val speed = getPropertyIfSet("Speed", "speed", 2.778, String::toDouble)
-    val shouldDropItems = getPropertyIfSet("Item Drop", "drop_items", false, String::toBoolean)
-
-    val uselessItems = if (shouldDropItems) {
-        mapOf(
+    uselessItems = mapOf(
                 Pair(ItemId.ITEM_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_REVIVE", "item_revive", 20, String::toInt)),
                 Pair(ItemId.ITEM_MAX_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_MAX_REVIVE", "item_max_revive", 10, String::toInt)),
                 Pair(ItemId.ITEM_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_POTION", "item_potion", 0, String::toInt)),
@@ -51,69 +48,49 @@ class Settings(val properties: Properties) {
                 Pair(ItemId.ITEM_ULTRA_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_ULTRA_BALL", "item_ultra_ball", 50, String::toInt)),
                 Pair(ItemId.ITEM_MASTER_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_MASTER_BALL", "item_master_ball", 10, String::toInt)),
                 Pair(ItemId.ITEM_RAZZ_BERRY, getPropertyIfSet("Max number of items to keep from type ITEM_RAZZ_BERRY", "item_razz_berry", 50, String::toInt))
-        )
-    } else {
-        mapOf(
-                Pair(ItemId.ITEM_REVIVE, 20),
-                Pair(ItemId.ITEM_MAX_REVIVE, 10),
-                Pair(ItemId.ITEM_POTION, 0),
-                Pair(ItemId.ITEM_SUPER_POTION, 30),
-                Pair(ItemId.ITEM_HYPER_POTION, 50),
-                Pair(ItemId.ITEM_MAX_POTION, 50),
-                Pair(ItemId.ITEM_POKE_BALL, 50),
-                Pair(ItemId.ITEM_GREAT_BALL, 50),
-                Pair(ItemId.ITEM_ULTRA_BALL, 50),
-                Pair(ItemId.ITEM_MASTER_BALL, 10),
-                Pair(ItemId.ITEM_RAZZ_BERRY, 50)
-        )
-    }
+        ),
 
-    val randomNextPokestop = getPropertyIfSet("Number of pokestops to select next", "random_next_pokestop_selection", 5, String::toInt)
+    randomNextPokestop = getPropertyIfSet("Number of pokestops to select next", "random_next_pokestop_selection", 5, String::toInt),
 
-    val desiredCatchProbability = getPropertyIfSet("Desired chance to catch a Pokemon with 1 ball", "desired_catch_probability", 0.4, String::toDouble)
-    val desiredCatchProbabilityUnwanted = getPropertyIfSet("Desired probability to catch unwanted Pokemon (obligatory_transfer; low IV; low CP)", "desired_catch_probability_unwanted", 0.0, String::toDouble)
-    val shouldAutoTransfer = getPropertyIfSet("Autotransfer", "autotransfer", false, String::toBoolean)
-    val keepPokemonAmount = getPropertyIfSet("minimum keep pokemon amount", "keep_pokemon_amount", 1, String::toInt)
-    val maxPokemonAmount = getPropertyIfSet("maximum keep pokemon amount", "max_pokemon_amount", -1, String::toInt)
-    val shouldDisplayKeepalive = getPropertyIfSet("Display Keepalive Coordinates", "display_keepalive", true, String::toBoolean)
+    desiredCatchProbability = getPropertyIfSet("Desired chance to catch a Pokemon with 1 ball", "desired_catch_probability", 0.4, String::toDouble),
+    desiredCatchProbabilityUnwanted = getPropertyIfSet("Desired probability to catch unwanted Pokemon (obligatory_transfer; low IV; low CP)", "desired_catch_probability_unwanted", 0.0, String::toDouble),
+    shouldAutoTransfer = getPropertyIfSet("Autotransfer", "autotransfer", false, String::toBoolean),
+    keepPokemonAmount = getPropertyIfSet("minimum keep pokemon amount", "keep_pokemon_amount", 1, String::toInt),
+    maxPokemonAmount = getPropertyIfSet("maximum keep pokemon amount", "max_pokemon_amount", -1, String::toInt),
+    shouldDisplayKeepalive = getPropertyIfSet("Display Keepalive Coordinates", "display_keepalive", true, String::toBoolean),
 
-    val shouldDisplayPokestopName = getPropertyIfSet("Display Pokestop Name", "display_pokestop_name", false, String::toBoolean)
-    val shouldDisplayPokestopSpinRewards = getPropertyIfSet("Display Pokestop Rewards", "display_pokestop_rewards", true, String::toBoolean)
-    val shouldDisplayPokemonCatchRewards = getPropertyIfSet("Display Pokemon Catch Rewards", "display_pokemon_catch_rewards", true, String::toBoolean)
+    shouldDisplayPokestopName = getPropertyIfSet("Display Pokestop Name", "display_pokestop_name", false, String::toBoolean),
+    shouldDisplayPokestopSpinRewards = getPropertyIfSet("Display Pokestop Rewards", "display_pokestop_rewards", true, String::toBoolean),
+    shouldDisplayPokemonCatchRewards = getPropertyIfSet("Display Pokemon Catch Rewards", "display_pokemon_catch_rewards", true, String::toBoolean),
 
-    val shouldLootPokestop = getPropertyIfSet("Loot Pokestops", "loot_pokestop", true, String::toBoolean)
-    var shouldCatchPokemons = getPropertyIfSet("Catch Pokemons", "catch_pokemon", true, String::toBoolean)
-    val shouldAutoFillIncubators = getPropertyIfSet("Auto Fill Incubators", "auto_fill_incubator", true, String::toBoolean)
+    shouldLootPokestop = getPropertyIfSet("Loot Pokestops", "loot_pokestop", true, String::toBoolean),
+    shouldCatchPokemons = getPropertyIfSet("Catch Pokemons", "catch_pokemon", true, String::toBoolean),
+    shouldAutoFillIncubators = getPropertyIfSet("Auto Fill Incubators", "auto_fill_incubator", true, String::toBoolean),
 
-    val sortByIV = getPropertyIfSet("Sort by IV first instead of CP", "sort_by_iv", false, String::toBoolean)
+    sortByIV = getPropertyIfSet("Sort by IV first instead of CP", "sort_by_iv", false, String::toBoolean),
 
-    val alwaysCurve = getPropertyIfSet("Always throw curveballs", "always_curve", false, String::toBoolean)
+    alwaysCurve = getPropertyIfSet("Always throw curveballs", "always_curve", false, String::toBoolean),
 
-    val neverUseBerries = getPropertyIfSet("Never use berries", "never_use_berries", true, String::toBoolean)
+    neverUseBerries = getPropertyIfSet("Never use berries", "never_use_berries", true, String::toBoolean),
 
-    val allowLeaveStartArea = getPropertyIfSet("Allow leaving the starting area", "allow_leave_start_area", false, String::toBoolean)
+    allowLeaveStartArea = getPropertyIfSet("Allow leaving the starting area", "allow_leave_start_area", false, String::toBoolean),
 
-    val spawnRadius = getPropertyIfSet("Max distance from starting point the bot should ever go", "spawn_radius", -1, String::toInt)
+    spawnRadius = getPropertyIfSet("Max distance from starting point the bot should ever go", "spawn_radius", -1, String::toInt),
 
-    val transferCPThreshold = getPropertyIfSet("Minimum CP to keep a pokemon", "transfer_cp_threshold", 400, String::toInt)
+    transferCPThreshold = getPropertyIfSet("Minimum CP to keep a pokemon", "transfer_cp_threshold", 400, String::toInt),
 
-    val transferIVThreshold = getPropertyIfSet("Minimum IV percentage to keep a pokemon", "transfer_iv_threshold", 80, String::toInt)
+    transferIVThreshold = getPropertyIfSet("Minimum IV percentage to keep a pokemon", "transfer_iv_threshold", 80, String::toInt),
 
-    val ignoredPokemon = if (shouldAutoTransfer) {
-        getPropertyIfSet("Never transfer these Pokemon", "ignored_pokemon", "EEVEE,MEWTWO,CHARMANDER", String::toString).split(",")
-    } else {
-        listOf()
-    }
-    val obligatoryTransfer = if (shouldAutoTransfer) {
-        getPropertyIfSet("list of pokemon you always want to transfer regardless of CP", "obligatory_transfer", "DODUO,RATTATA,CATERPIE,PIDGEY", String::toString).split(",")
-    } else {
-        listOf()
-    }
+    ignoredPokemon = getPropertyIfSet("Never transfer these Pokemon", "ignored_pokemon", "EEVEE,MEWTWO,CHARMANDER", String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
 
-    val guiPort = getPropertyIfSet("Port where the webserver should listen", "gui_port", 8000, String::toInt)
-    val guiPortSocket = getPropertyIfSet("Port where the socketserver should listen", "gui_port_socket", 8001, String::toInt)
+    obligatoryTransfer = getPropertyIfSet("list of pokemon you always want to transfer regardless of CP", "obligatory_transfer", "DODUO,RATTATA,CATERPIE,PIDGEY", String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
 
-    private fun <T> getPropertyOrDie(description: String, property: String, conversion: (String) -> T): T {
+    guiPort = getPropertyIfSet("Port where the webserver should listen", "gui_port", 8000, String::toInt),
+    guiPortSocket = getPropertyIfSet("Port where the socketserver should listen", "gui_port_socket", 8001, String::toInt)
+    )
+}
+
+    fun <T> getPropertyOrDie(description: String, property: String, conversion: (String) -> T): T {
         val settingString = "$description setting (\"$property\")"
 
         if (!properties.containsKey(property)) {
@@ -132,7 +109,7 @@ class Settings(val properties: Properties) {
         return result
     }
 
-    private fun <T> getPropertyIfSet(description: String, property: String, default: T, conversion: (String) -> T): T {
+    fun <T> getPropertyIfSet(description: String, property: String, default: T, conversion: (String) -> T): T {
         val settingString = "$description setting (\"$property\")"
         val defaulting = "defaulting to \"$default\""
 
@@ -148,18 +125,69 @@ class Settings(val properties: Properties) {
             return default
         }
     }
+}
 
-    fun setToken(value: String) {
-        properties.setProperty("token", value)
-    }
+data class Settings(
+    val profileUpdateTimer: Long = 60,
+    val startingLatitude: Double,
+    val startingLongitude: Double,
 
-    fun writeProperty(propertyFile: String, key: String) {
+    val startingLocation: S2LatLng = S2LatLng.fromDegrees(startingLatitude, startingLongitude),
+    val credentials: Credentials,
+    val speed: Double = 2.778,
+    val shouldDropItems: Boolean = false,
+    val uselessItems: Map<ItemId, Int> = mapOf(
+        Pair(ItemId.ITEM_REVIVE, 20),
+        Pair(ItemId.ITEM_MAX_REVIVE, 10),
+        Pair(ItemId.ITEM_POTION, 0),
+        Pair(ItemId.ITEM_SUPER_POTION, 30),
+        Pair(ItemId.ITEM_HYPER_POTION, 50),
+        Pair(ItemId.ITEM_MAX_POTION, 50),
+        Pair(ItemId.ITEM_POKE_BALL, 50),
+        Pair(ItemId.ITEM_GREAT_BALL, 50),
+        Pair(ItemId.ITEM_ULTRA_BALL, 50),
+        Pair(ItemId.ITEM_MASTER_BALL, 10),
+        Pair(ItemId.ITEM_RAZZ_BERRY, 50)
+    ),
+
+    val randomNextPokestop: Int = 5,
+    val desiredCatchProbability: Double = 0.4,
+    val desiredCatchProbabilityUnwanted: Double = 0.0,
+    val shouldAutoTransfer: Boolean = false,
+    val keepPokemonAmount: Int = 1,
+    val maxPokemonAmount: Int = -1,
+    val shouldDisplayKeepalive: Boolean = true,
+
+    val shouldDisplayPokestopName: Boolean = false,
+    val shouldDisplayPokestopSpinRewards: Boolean = true,
+    val shouldDisplayPokemonCatchRewards: Boolean = true,
+
+    val shouldLootPokestop: Boolean = true,
+    var shouldCatchPokemons: Boolean = true,
+    val shouldAutoFillIncubators: Boolean = true,
+
+    val sortByIV: Boolean = false,
+    val alwaysCurve: Boolean = false,
+    val neverUseBerries: Boolean = true,
+    val allowLeaveStartArea: Boolean = false,
+    val spawnRadius: Int = -1,
+    val transferCPThreshold: Int = 400,
+    val transferIVThreshold: Int = 80,
+    val ignoredPokemon: List<PokemonId> = listOf(PokemonId.EEVEE, PokemonId.MEWTWO),
+
+    val obligatoryTransfer: List<PokemonId> = listOf(PokemonId.DODUO, PokemonId.RATTATA, PokemonId.CATERPIE, PokemonId.PIDGEY),
+
+    val guiPort: Int = 8000,
+    val guiPortSocket: Int = 8001
+) {
+
+    fun writeProperty(propertyFile: String, key: String, value: Any) {
         // TODO: This function does not work with lists, like obligatory_transfer
         val file = BufferedReader(FileReader(propertyFile))
         var propertiesText = String()
         var foundKey = false
 
-        val newKeyValue = "$key=${this.properties.getProperty(key)}\r\n"
+        val newKeyValue = "$key=${value.toString()}\r\n"
 
         file.lines().forEach {
             if (it != null && it.startsWith(key)) {
@@ -181,3 +209,12 @@ class Settings(val properties: Properties) {
         out.close()
     }
 }
+
+interface Credentials
+
+data class GoogleCredentials(var token: String = ""): Credentials
+
+data class PtcCredentials(
+    val username: String = "",
+    val password: String = ""
+): Credentials

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -21,8 +21,11 @@ import java.util.Properties
 
 class SettingsParser(val properties: Properties) {
     fun createSettingsFromProperties(): Settings {
+        val defaults = Settings(credentials = GoogleCredentials(), startingLatitude = 0.0, startingLongitude = 0.0)
+        val shouldDropItems = getPropertyIfSet("Item Drop", "drop_items", defaults.shouldDropItems, String::toBoolean)
+
         return Settings(
-            profileUpdateTimer = getPropertyIfSet("Set Profile Update Timer", "profile_update_timer", 60, String::toLong),
+            profileUpdateTimer = getPropertyIfSet("Set Profile Update Timer", "profile_update_timer", defaults.profileUpdateTimer, String::toLong),
 
             startingLatitude = getPropertyOrDie("Starting Latitude", "latitude", String::toDouble),
             startingLongitude = getPropertyOrDie("Starting Longitude", "longitude", String::toDouble),
@@ -35,10 +38,10 @@ class SettingsParser(val properties: Properties) {
                 PtcCredentials(properties.getProperty("username"), getPasswordProperty())
             },
 
-            speed = getPropertyIfSet("Speed", "speed", 2.778, String::toDouble),
-            shouldDropItems = getPropertyIfSet("Item Drop", "drop_items", false, String::toBoolean),
+            speed = getPropertyIfSet("Speed", "speed", defaults.speed, String::toDouble),
+            shouldDropItems = shouldDropItems,
 
-            uselessItems = mapOf(
+            uselessItems = if(shouldDropItems) mapOf(
                 Pair(ItemId.ITEM_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_REVIVE", "item_revive", 20, String::toInt)),
                 Pair(ItemId.ITEM_MAX_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_MAX_REVIVE", "item_max_revive", 10, String::toInt)),
                 Pair(ItemId.ITEM_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_POTION", "item_potion", 0, String::toInt)),
@@ -50,45 +53,45 @@ class SettingsParser(val properties: Properties) {
                 Pair(ItemId.ITEM_ULTRA_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_ULTRA_BALL", "item_ultra_ball", 50, String::toInt)),
                 Pair(ItemId.ITEM_MASTER_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_MASTER_BALL", "item_master_ball", 10, String::toInt)),
                 Pair(ItemId.ITEM_RAZZ_BERRY, getPropertyIfSet("Max number of items to keep from type ITEM_RAZZ_BERRY", "item_razz_berry", 50, String::toInt))
-            ),
+            ) else mapOf(),
 
-            randomNextPokestop = getPropertyIfSet("Number of pokestops to select next", "random_next_pokestop_selection", 5, String::toInt),
+            randomNextPokestop = getPropertyIfSet("Number of pokestops to select next", "random_next_pokestop_selection", defaults.randomNextPokestop, String::toInt),
 
-            desiredCatchProbability = getPropertyIfSet("Desired chance to catch a Pokemon with 1 ball", "desired_catch_probability", 0.4, String::toDouble),
-            desiredCatchProbabilityUnwanted = getPropertyIfSet("Desired probability to catch unwanted Pokemon (obligatory_transfer; low IV; low CP)", "desired_catch_probability_unwanted", 0.0, String::toDouble),
-            shouldAutoTransfer = getPropertyIfSet("Autotransfer", "autotransfer", false, String::toBoolean),
-            keepPokemonAmount = getPropertyIfSet("minimum keep pokemon amount", "keep_pokemon_amount", 1, String::toInt),
-            maxPokemonAmount = getPropertyIfSet("maximum keep pokemon amount", "max_pokemon_amount", -1, String::toInt),
-            shouldDisplayKeepalive = getPropertyIfSet("Display Keepalive Coordinates", "display_keepalive", true, String::toBoolean),
+            desiredCatchProbability = getPropertyIfSet("Desired chance to catch a Pokemon with 1 ball", "desired_catch_probability", defaults.desiredCatchProbability, String::toDouble),
+            desiredCatchProbabilityUnwanted = getPropertyIfSet("Desired probability to catch unwanted Pokemon (obligatory_transfer; low IV; low CP)", "desired_catch_probability_unwanted", defaults.desiredCatchProbabilityUnwanted, String::toDouble),
+            shouldAutoTransfer = getPropertyIfSet("Autotransfer", "autotransfer", defaults.shouldAutoTransfer, String::toBoolean),
+            keepPokemonAmount = getPropertyIfSet("minimum keep pokemon amount", "keep_pokemon_amount", defaults.keepPokemonAmount, String::toInt),
+            maxPokemonAmount = getPropertyIfSet("maximum keep pokemon amount", "max_pokemon_amount", defaults.maxPokemonAmount, String::toInt),
+            shouldDisplayKeepalive = getPropertyIfSet("Display Keepalive Coordinates", "display_keepalive", defaults.shouldDisplayKeepalive, String::toBoolean),
 
-            shouldDisplayPokestopName = getPropertyIfSet("Display Pokestop Name", "display_pokestop_name", false, String::toBoolean),
-            shouldDisplayPokestopSpinRewards = getPropertyIfSet("Display Pokestop Rewards", "display_pokestop_rewards", true, String::toBoolean),
-            shouldDisplayPokemonCatchRewards = getPropertyIfSet("Display Pokemon Catch Rewards", "display_pokemon_catch_rewards", true, String::toBoolean),
+            shouldDisplayPokestopName = getPropertyIfSet("Display Pokestop Name", "display_pokestop_name", defaults.shouldDisplayPokestopName, String::toBoolean),
+            shouldDisplayPokestopSpinRewards = getPropertyIfSet("Display Pokestop Rewards", "display_pokestop_rewards", defaults.shouldDisplayPokestopSpinRewards, String::toBoolean),
+            shouldDisplayPokemonCatchRewards = getPropertyIfSet("Display Pokemon Catch Rewards", "display_pokemon_catch_rewards", defaults.shouldDisplayPokemonCatchRewards, String::toBoolean),
 
-            shouldLootPokestop = getPropertyIfSet("Loot Pokestops", "loot_pokestop", true, String::toBoolean),
-            shouldCatchPokemons = getPropertyIfSet("Catch Pokemons", "catch_pokemon", true, String::toBoolean),
-            shouldAutoFillIncubators = getPropertyIfSet("Auto Fill Incubators", "auto_fill_incubator", true, String::toBoolean),
+            shouldLootPokestop = getPropertyIfSet("Loot Pokestops", "loot_pokestop", defaults.shouldLootPokestop, String::toBoolean),
+            shouldCatchPokemons = getPropertyIfSet("Catch Pokemons", "catch_pokemon", defaults.shouldCatchPokemons, String::toBoolean),
+            shouldAutoFillIncubators = getPropertyIfSet("Auto Fill Incubators", "auto_fill_incubator", defaults.shouldAutoFillIncubators, String::toBoolean),
 
-            sortByIV = getPropertyIfSet("Sort by IV first instead of CP", "sort_by_iv", false, String::toBoolean),
+            sortByIV = getPropertyIfSet("Sort by IV first instead of CP", "sort_by_iv", defaults.sortByIV, String::toBoolean),
 
-            alwaysCurve = getPropertyIfSet("Always throw curveballs", "always_curve", false, String::toBoolean),
+            alwaysCurve = getPropertyIfSet("Always throw curveballs", "always_curve", defaults.alwaysCurve, String::toBoolean),
 
-            neverUseBerries = getPropertyIfSet("Never use berries", "never_use_berries", true, String::toBoolean),
+            neverUseBerries = getPropertyIfSet("Never use berries", "never_use_berries", defaults.neverUseBerries, String::toBoolean),
 
-            allowLeaveStartArea = getPropertyIfSet("Allow leaving the starting area", "allow_leave_start_area", false, String::toBoolean),
+            allowLeaveStartArea = getPropertyIfSet("Allow leaving the starting area", "allow_leave_start_area", defaults.allowLeaveStartArea, String::toBoolean),
 
-            spawnRadius = getPropertyIfSet("Max distance from starting point the bot should ever go", "spawn_radius", -1, String::toInt),
+            spawnRadius = getPropertyIfSet("Max distance from starting point the bot should ever go", "spawn_radius", defaults.spawnRadius, String::toInt),
 
-            transferCPThreshold = getPropertyIfSet("Minimum CP to keep a pokemon", "transfer_cp_threshold", 400, String::toInt),
+            transferCPThreshold = getPropertyIfSet("Minimum CP to keep a pokemon", "transfer_cp_threshold", defaults.transferCPThreshold, String::toInt),
 
-            transferIVThreshold = getPropertyIfSet("Minimum IV percentage to keep a pokemon", "transfer_iv_threshold", 80, String::toInt),
+            transferIVThreshold = getPropertyIfSet("Minimum IV percentage to keep a pokemon", "transfer_iv_threshold", defaults.transferIVThreshold, String::toInt),
 
-            ignoredPokemon = getPropertyIfSet("Never transfer these Pokemon", "ignored_pokemon", "EEVEE,MEWTWO,CHARMANDER", String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
+            ignoredPokemon = getPropertyIfSet("Never transfer these Pokemon", "ignored_pokemon", defaults.ignoredPokemon.map {it.name}.joinToString(","), String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
 
-            obligatoryTransfer = getPropertyIfSet("list of pokemon you always want to transfer regardless of CP", "obligatory_transfer", "DODUO,RATTATA,CATERPIE,PIDGEY", String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
+            obligatoryTransfer = getPropertyIfSet("list of pokemon you always want to transfer regardless of CP", "obligatory_transfer", defaults.obligatoryTransfer.map {it.name}.joinToString(","), String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
 
-            guiPort = getPropertyIfSet("Port where the webserver should listen", "gui_port", 8000, String::toInt),
-            guiPortSocket = getPropertyIfSet("Port where the socketserver should listen", "gui_port_socket", 8001, String::toInt)
+            guiPort = getPropertyIfSet("Port where the webserver should listen", "gui_port", defaults.guiPort, String::toInt),
+            guiPortSocket = getPropertyIfSet("Port where the socketserver should listen", "gui_port_socket", defaults.guiPortSocket, String::toInt)
         )
     }
 
@@ -221,5 +224,4 @@ interface Credentials
 data class GoogleCredentials(var token: String = "") : Credentials
 data class GoogleAutoCredentials(var username: String = "", var password: String = "") : Credentials
 
-data class PtcCredentials( val username: String = "", val password: String = ""
-) : Credentials
+data class PtcCredentials(val username: String = "", val password: String = "") : Credentials

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
@@ -35,7 +35,7 @@ class CatchOneNearbyPokemon : Task {
 
         if (pokemon.isNotEmpty()) {
             val catchablePokemon = pokemon.first()
-            if (settings.obligatoryTransfer.contains(catchablePokemon.pokemonId.name) && settings.desiredCatchProbabilityUnwanted == -1.0) {
+            if (settings.obligatoryTransfer.contains(catchablePokemon.pokemonId) && settings.desiredCatchProbabilityUnwanted == -1.0) {
                 ctx.blacklistedEncounters.add(catchablePokemon.encounterId)
                 Log.normal("Found pokemon ${catchablePokemon.pokemonId}; blacklisting because it's unwanted")
                 return

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
@@ -37,7 +37,7 @@ class ReleasePokemon : Task {
                 if (!isFavourite) {
                     val ivPercentage = pokemon.getIvPercentage()
                     // never transfer highest rated Pokemon (except for obligatory transfer)
-                    if (settings.obligatoryTransfer.contains(pokemon.pokemonId.name) || index >= settings.keepPokemonAmount) {
+                    if (settings.obligatoryTransfer.contains(pokemon.pokemonId) || index >= settings.keepPokemonAmount) {
                         val (shouldRelease, reason) = pokemon.shouldTransfer(settings, pokemonCounts)
 
                         if (shouldRelease) {

--- a/src/main/kotlin/ink/abb/pogo/scraper/util/pokemon/Pokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/util/pokemon/Pokemon.kt
@@ -48,9 +48,9 @@ fun Pokemon.shouldTransfer(settings: Settings, pokemonCounts: MutableMap<String,
     // add 1 to the map
     val isTooMany = isTooMany(settings, pokemonCounts, this)
 
-    var shouldRelease = obligatoryTransfer.contains(this.pokemonId.name)
+    var shouldRelease = obligatoryTransfer.contains(this.pokemonId)
     var reason: String = "Obligatory transfer"
-    if (!ignoredPokemon.contains(this.pokemonId.name)) {
+    if (!ignoredPokemon.contains(this.pokemonId)) {
         // shouldn't release? check for IV/CP
         if (!shouldRelease) {
             var ivTooLow = false

--- a/src/main/kotlin/ink/abb/pogo/scraper/util/pokemon/PokemonData.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/util/pokemon/PokemonData.kt
@@ -35,9 +35,9 @@ fun PokemonData.shouldTransfer(settings: Settings): Pair<Boolean, String> {
     val minIVPercentage = settings.transferIVThreshold
     val minCP = settings.transferCPThreshold
 
-    var shouldRelease = obligatoryTransfer.contains(this.pokemonId.name)
+    var shouldRelease = obligatoryTransfer.contains(this.pokemonId)
     var reason: String = "Obligatory transfer"
-    if (!ignoredPokemon.contains(this.pokemonId.name)) {
+    if (!ignoredPokemon.contains(this.pokemonId)) {
         if (!shouldRelease) {
             var ivTooLow = false
             var cpTooLow = false


### PR DESCRIPTION
Right now the properties are parsed from config.properties in the construction of the Settings object - this means Settings can only ever come from properties files.

This change decouples the Settings and the config.properties file, adding a factory method that creates a Settings instance from a config.properties file like before.

This allows us to store settings files anywhere - not just properties files on disk.

- [x] Separate settings
- [x] Fix google passwordless login