### PR TITLE
[WIP] Re-work web ui architecture

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "com.corundumstudio.socketio:netty-socketio:1.7.7"
+    compile "com.sparkjava:spark-core:2.5"
     compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.21'
 
     testCompile group: 'junit', name: 'junit', version: '4.11'

--- a/src/main/kotlin/ink/abb/pogo/scraper/Bot.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Bot.kt
@@ -122,7 +122,7 @@ class Bot(val api: PokemonGo, val settings: Settings) {
 
         if(settings.guiPort > 0){
             Log.normal("Running webserver on port ${settings.guiPort}")
-            WebServer().start(settings.guiPort, settings.guiPortSocket)
+            WebServer().start(ctx, settings.guiPort, settings.guiPortSocket)
             ctx.server.start(ctx, settings.guiPortSocket)
         }
     }

--- a/src/main/kotlin/ink/abb/pogo/scraper/gui/WebServer.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/gui/WebServer.kt
@@ -8,6 +8,7 @@
 
 package ink.abb.pogo.scraper.gui
 
+import ink.abb.pogo.scraper.Context
 import spark.Request
 import spark.Response
 import spark.Spark.get
@@ -18,12 +19,13 @@ import java.util.stream.Collectors
 
 class WebServer {
 
-    fun start(port: Int, socketPort: Int) {
+    fun start(ctx: Context, port: Int, socketPort: Int) {
         port(port)
         get("/") { request: Request, response: Response ->
             val string = BufferedReader(InputStreamReader(WebServer::class.java.getResourceAsStream("index.html")))
                     .lines().collect(Collectors.joining("\n"))
                     .replace("{{socketPort}}", socketPort.toString())
+                    .replace("{{username}}", ctx.api.playerProfile.username)
             response.header("Access-Control-Allow-Origin", "*")
             string
         }

--- a/src/main/kotlin/ink/abb/pogo/scraper/gui/WebServer.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/gui/WebServer.kt
@@ -8,43 +8,24 @@
 
 package ink.abb.pogo.scraper.gui
 
-import com.sun.net.httpserver.HttpExchange
-import com.sun.net.httpserver.HttpHandler
-import com.sun.net.httpserver.HttpServer
+import spark.Request
+import spark.Response
+import spark.Spark.get
+import spark.Spark.port
 import java.io.BufferedReader
-import java.io.IOException
 import java.io.InputStreamReader
-import java.net.InetSocketAddress
-import java.nio.charset.Charset
-import java.nio.file.Files
-import java.nio.file.Paths
 import java.util.stream.Collectors
 
 class WebServer {
-    @Throws(Exception::class)
+
     fun start(port: Int, socketPort: Int) {
-        Thread(){
-            val server = HttpServer.create(InetSocketAddress(port), 0)
-            server.createContext("/", RootHandler(socketPort))
-            server.executor = null
-            server.start()
-        }.start()
-    }
-
-    inner class RootHandler(val socketPort: Int) : HttpHandler {
-
-        @Throws(IOException::class)
-        override fun handle(t: HttpExchange) {
-
+        port(port)
+        get("/") { request: Request, response: Response ->
             val string = BufferedReader(InputStreamReader(WebServer::class.java.getResourceAsStream("index.html")))
                     .lines().collect(Collectors.joining("\n"))
                     .replace("{{socketPort}}", socketPort.toString())
-            val bytes = string.toByteArray(Charset.forName("UTF-8"))
-            t.responseHeaders.set("Content-Type", "text/html; charset=UTF-8")
-            t.responseHeaders.set("Access-Control-Allow-Origin", "*")
-            t.sendResponseHeaders(200, bytes.size.toLong())
-            t.responseBody.write(bytes)
-            t.responseBody.close()
+            response.header("Access-Control-Allow-Origin", "*")
+            string
         }
     }
 }

--- a/src/main/resources/ink/abb/pogo/scraper/gui/index.html
+++ b/src/main/resources/ink/abb/pogo/scraper/gui/index.html
@@ -10,7 +10,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Pokemon Go Bot GUI</title>
+    <title>{{username}} - Pokemon Go Bot GUI</title>
 
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">


### PR DESCRIPTION
**Fixed issue:** Mostly not a fix, but still added a fix for #534 

**Changes made:**

* Introduced Spark as lightweight web framework to serve the GUI and maybe more later (REST API?)
* Added trainer name to page title

**To dos (Yet this can be merged on its own)**

- [ ] Split up the huge HTML into the template, JS and CSS file for reusability.
    - [ ] Introduce a real templating engine
    - [ ] Remove the String replacements with actual models
    - [ ] Move all assets to respective folders
- [ ] Migrate to Spark's Jetty WebSocket

**Discussion about To dos**
About the templating: There are tons of options for a templating engine. Spark supports several out of the box, see a list here: http://sparkjava.com/documentation.html#views-templates
I personally have used Pebble before, which worked fine. Thymeleaf comes with the benefit that previews still render as normal HTML but the learning curve is steep. Velocity is recommended often and very mature.
To be honest, we probably won't need that many features for now, but we should keep the options open if the web gui gets bigger.

About the websocket: Spark comes with Jetty which comes with a websocket server. Problem is we use Socket.IO right now which is kinda convenient but also a bit special, so not easy to adapt. The only real advantage of moving would be one less dependency and being able to use the same port as the website is running on also for the websocket. But not sure if that's worth it.