### PR TITLE
Added limits for other items and adjusted default values

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -40,17 +40,21 @@ drop_items=true
 
 # max number of each item that the bot should keep if "drop_items" is enabled
 # use -1 in a item to never drop this specific item
+# the default values add up to 350
 item_revive=20
 item_max_revive=10
 item_potion=0
 item_super_potion=30
 item_hyper_potion=50
 item_max_potion=50
-item_poke_ball=50
-item_great_ball=50
+item_poke_ball=40
+item_great_ball=45
 item_ultra_ball=50
-item_master_ball=50
-item_razz_berry=50
+item_master_ball=10
+item_razz_berry=30
+item_lucky_egg=5
+item_incense=5
+item_lure_module=5
 
 ## Extra Info
 # should the bot display rewards pokestop (true/false)

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -40,32 +40,23 @@ class Settings(val properties: Properties) {
 
     val uselessItems = if (shouldDropItems) {
         mapOf(
-                Pair(ItemId.ITEM_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_REVIVE", "item_revive", 20, String::toInt)),
-                Pair(ItemId.ITEM_MAX_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_MAX_REVIVE", "item_max_revive", 10, String::toInt)),
-                Pair(ItemId.ITEM_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_POTION", "item_potion", 0, String::toInt)),
-                Pair(ItemId.ITEM_SUPER_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_SUPER_POTION", "item_super_potion", 30, String::toInt)),
-                Pair(ItemId.ITEM_HYPER_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_HYPER_POTION", "item_hyper_potion", 50, String::toInt)),
-                Pair(ItemId.ITEM_MAX_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_MAX_POTION", "item_max_potion", 50, String::toInt)),
-                Pair(ItemId.ITEM_POKE_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_POKE_BALL", "item_poke_ball", 50, String::toInt)),
-                Pair(ItemId.ITEM_GREAT_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_GREAT_BALL", "item_great_ball", 50, String::toInt)),
-                Pair(ItemId.ITEM_ULTRA_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_ULTRA_BALL", "item_ultra_ball", 50, String::toInt)),
-                Pair(ItemId.ITEM_MASTER_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_MASTER_BALL", "item_master_ball", 10, String::toInt)),
-                Pair(ItemId.ITEM_RAZZ_BERRY, getPropertyIfSet("Max number of items to keep from type ITEM_RAZZ_BERRY", "item_razz_berry", 50, String::toInt))
+            Pair(ItemId.ITEM_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_REVIVE", "item_revive", 20, String::toInt)),
+            Pair(ItemId.ITEM_MAX_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_MAX_REVIVE", "item_max_revive", 10, String::toInt)),
+            Pair(ItemId.ITEM_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_POTION", "item_potion", 0, String::toInt)),
+            Pair(ItemId.ITEM_SUPER_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_SUPER_POTION", "item_super_potion", 30, String::toInt)),
+            Pair(ItemId.ITEM_HYPER_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_HYPER_POTION", "item_hyper_potion", 50, String::toInt)),
+            Pair(ItemId.ITEM_MAX_POTION, getPropertyIfSet("Max number of items to keep from type ITEM_MAX_POTION", "item_max_potion", 50, String::toInt)),
+            Pair(ItemId.ITEM_POKE_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_POKE_BALL", "item_poke_ball", 40, String::toInt)),
+            Pair(ItemId.ITEM_GREAT_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_GREAT_BALL", "item_great_ball", 45, String::toInt)),
+            Pair(ItemId.ITEM_ULTRA_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_ULTRA_BALL", "item_ultra_ball", 50, String::toInt)),
+            Pair(ItemId.ITEM_MASTER_BALL, getPropertyIfSet("Max number of items to keep from type ITEM_MASTER_BALL", "item_master_ball", 10, String::toInt)),
+            Pair(ItemId.ITEM_RAZZ_BERRY, getPropertyIfSet("Max number of items to keep from type ITEM_RAZZ_BERRY", "item_razz_berry", 30, String::toInt)),
+            Pair(ItemId.ITEM_LUCKY_EGG, getPropertyIfSet("Max number of items to keep from type ITEM_LUCKY_EGG", "item_lucky_egg", 5, String::toInt)),
+            Pair(ItemId.ITEM_INCENSE_ORDINARY, getPropertyIfSet("Max number of items to keep from type ITEM_INCENSE_ORDINARY", "item_incense", 5, String::toInt)),
+            Pair(ItemId.ITEM_TROY_DISK, getPropertyIfSet("Max number of items to keep from type ITEM_TROY_DISK (lure module)", "item_lure_module", 5, String::toInt))
         )
     } else {
-        mapOf(
-                Pair(ItemId.ITEM_REVIVE, 20),
-                Pair(ItemId.ITEM_MAX_REVIVE, 10),
-                Pair(ItemId.ITEM_POTION, 0),
-                Pair(ItemId.ITEM_SUPER_POTION, 30),
-                Pair(ItemId.ITEM_HYPER_POTION, 50),
-                Pair(ItemId.ITEM_MAX_POTION, 50),
-                Pair(ItemId.ITEM_POKE_BALL, 50),
-                Pair(ItemId.ITEM_GREAT_BALL, 50),
-                Pair(ItemId.ITEM_ULTRA_BALL, 50),
-                Pair(ItemId.ITEM_MASTER_BALL, 10),
-                Pair(ItemId.ITEM_RAZZ_BERRY, 50)
-        )
+        emptyMap()
     }
 
     val randomNextPokestop = getPropertyIfSet("Number of pokestops to select next", "random_next_pokestop_selection", 5, String::toInt)

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/UpdateProfile.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/UpdateProfile.kt
@@ -44,6 +44,7 @@ class UpdateProfile : Task {
             )
             ctx.server.sendProfile()
         } catch (e: Exception) {
+            Log.red("Failed to update profile and inventories")
         }
     }
 }


### PR DESCRIPTION
**Fixed issue:** #494 (partially)

**Changes made:**

* Added item limit for lucky egg, incense, lure module
* Adjusted default values to add up to 350

This will partially solve the inventory overflow reported in #494 since now all items are taken into account. There still seems to be an issue that the profile is not being updated correctly when the bot is run for a long time.
