### PR TITLE
added break free for walk checks

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Thu Jul 28 19:01:53 CEST 2016
+#Sun Jul 31 18:29:58 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/Walk.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/Walk.kt
@@ -164,7 +164,7 @@ class Walk(val sortedPokestops: List<Pokestop>, val lootTimeouts: Map<String, Lo
                     }
                 }
                 // don't run away when there are still Pokemon around
-                if (ctx.api.inventories.itemBag.hasPokeballs() && bot.api.map.getCatchablePokemon(ctx.blacklistedEncounters).size > 0 && settings.shouldCatchPokemons) {
+                if (pauseCounter > 0 && ctx.api.inventories.itemBag.hasPokeballs() && bot.api.map.getCatchablePokemon(ctx.blacklistedEncounters).size > 0 && settings.shouldCatchPokemons) {
                     // Stop walking
                     Log.normal("Pausing to catch pokemon...")
 

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/Walk.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/Walk.kt
@@ -167,9 +167,7 @@ class Walk(val sortedPokestops: List<Pokestop>, val lootTimeouts: Map<String, Lo
                 if (pauseCounter > 0 && ctx.api.inventories.itemBag.hasPokeballs() && bot.api.map.getCatchablePokemon(ctx.blacklistedEncounters).size > 0 && settings.shouldCatchPokemons) {
                     // Stop walking
                     Log.normal("Pausing to catch pokemon...")
-
-                    // Try to catch once, then wait for next walk loop
-//                    bot.task(CatchOneNearbyPokemon())
+                    pauseCounter = 2
                     return@runLoop
                 }
 

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToStartPokeStop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToStartPokeStop.kt
@@ -69,8 +69,7 @@ class WalkToStartPokeStop(val startPokeStop: Pokestop) : Task {
                 if (ctx.api.inventories.itemBag.hasPokeballs() && bot.api.map.getCatchablePokemon(ctx.blacklistedEncounters).size > 0 && settings.shouldCatchPokemons) {
                     // Stop walking
                     Log.normal("Pausing to catch pokemon...")
-                    // Try to catch once, then wait for next walk loop
-                    bot.task(CatchOneNearbyPokemon())
+                    pauseCounter = 2
 
                     return@runLoop
                 }
@@ -121,8 +120,7 @@ class WalkToStartPokeStop(val startPokeStop: Pokestop) : Task {
                 if (pauseCounter > 0 && ctx.api.inventories.itemBag.hasPokeballs() && bot.api.map.getCatchablePokemon(ctx.blacklistedEncounters).size > 0 && settings.shouldCatchPokemons) {
                     // Stop walking
                     Log.normal("Pausing to catch pokemon...")
-                    // Try to catch once, then wait for next walk loop
-                    bot.task(CatchOneNearbyPokemon())
+                    pauseCounter = 2
                     return@runLoop
                 }
                 val start = S2LatLng.fromDegrees(ctx.lat.get(), ctx.lng.get())

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToStartPokeStop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToStartPokeStop.kt
@@ -65,7 +65,7 @@ class WalkToStartPokeStop(val startPokeStop: Pokestop) : Task {
                 }
             }
             // don't run away when there are still Pokemon around
-            if (remainingSteps.toInt().mod(20) == 0)
+            if (remainingSteps.toInt().mod(20) == 0 && pauseCounter > 0)
                 if (ctx.api.inventories.itemBag.hasPokeballs() && bot.api.map.getCatchablePokemon(ctx.blacklistedEncounters).size > 0 && settings.shouldCatchPokemons) {
                     // Stop walking
                     Log.normal("Pausing to catch pokemon...")
@@ -118,7 +118,7 @@ class WalkToStartPokeStop(val startPokeStop: Pokestop) : Task {
                     }
                 }
                 // don't run away when there are still Pokemon around
-                if (ctx.api.inventories.itemBag.hasPokeballs() && bot.api.map.getCatchablePokemon(ctx.blacklistedEncounters).size > 0 && settings.shouldCatchPokemons) {
+                if (pauseCounter > 0 && ctx.api.inventories.itemBag.hasPokeballs() && bot.api.map.getCatchablePokemon(ctx.blacklistedEncounters).size > 0 && settings.shouldCatchPokemons) {
                     // Stop walking
                     Log.normal("Pausing to catch pokemon...")
                     // Try to catch once, then wait for next walk loop


### PR DESCRIPTION
The API caches the results for 5 seconds and the with the previous version the `CatchNearbyPokemon` gets called non stop (which was a previous fix for the unstable api). Removed that and replaced it with a api break OR fixed tries force break.