### PR TITLE
Disable ban_spin_count by default

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -102,8 +102,8 @@ allow_leave_start_area=false
 # (-1: only limited by the initial pokestops (~3*3km); with allow_leave_start_area=true unlimited)
 spawn_radius=-1
 
-# Number of times the pokestop should be spun to attempt softban bypass (0 to disable)
-ban_spin_count=40
+# Number of times the pokestop should be spun to attempt softban bypass (0 to disable, 40 recommended value to work)
+ban_spin_count=0
 
 # Set timer in seconds to go back to the starting pokestop (-1 disabled)
 timerWalkToStartPokeStop=-1

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -194,7 +194,7 @@ data class Settings(
     val neverUseBerries: Boolean = true,
     val allowLeaveStartArea: Boolean = false,
     val spawnRadius: Int = -1,
-    val banSpinCount: Int = 40,
+    val banSpinCount: Int = 0,
     val transferCPThreshold: Int = 400,
     val transferIVThreshold: Int = 80,
     val ignoredPokemon: List<PokemonId> = listOf(PokemonId.EEVEE, PokemonId.MEWTWO),


### PR DESCRIPTION
**Fixed issue:** At this moment it is uncertain if Niantic can/will detect this specific method as cheating (hopefully not).

**Changes made:**

* Let the user configure it to the recommended setting on their own risk :)