### PR TITLE
track how many pokemon were caught with lures

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -63,6 +63,9 @@ item_lure_module=-1
 # Should the bot display rewards pokestop (true/false)
 display_pokestop_rewards=true
 
+# Should the bot display if it caught a pokemon from a lure (true/false)
+display_if_pokemon_from_lure=true
+
 # Should the bot display rewards when catching pokemon (true/false)
 display_pokemon_catch_rewards=true
 

--- a/src/main/kotlin/ink/abb/pogo/scraper/Bot.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Bot.kt
@@ -45,6 +45,7 @@ class Bot(val api: PokemonGo, val settings: Settings) {
             AtomicDouble(settings.startingLongitude),
             AtomicLong(api.playerProfile.stats.experience),
             Pair(AtomicInteger(0), AtomicInteger(0)),
+            AtomicInteger(0),
             Pair(AtomicInteger(0), AtomicInteger(0)),
             mutableSetOf(),
             SocketServer()

--- a/src/main/kotlin/ink/abb/pogo/scraper/Context.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Context.kt
@@ -24,6 +24,7 @@ data class Context(
 
         val startXp: AtomicLong,
         val pokemonStats: Pair<AtomicInteger, AtomicInteger>,
+        val luredPokemonStats: AtomicInteger,
         val itemStats: Pair<AtomicInteger, AtomicInteger>,
 
         val blacklistedEncounters: MutableSet<Long>,

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -79,6 +79,7 @@ class SettingsParser(val properties: Properties) {
             shouldDisplayPokestopName = getPropertyIfSet("Display Pokestop Name", "display_pokestop_name", defaults.shouldDisplayPokestopName, String::toBoolean),
             shouldDisplayPokestopSpinRewards = getPropertyIfSet("Display Pokestop Rewards", "display_pokestop_rewards", defaults.shouldDisplayPokestopSpinRewards, String::toBoolean),
             shouldDisplayPokemonCatchRewards = getPropertyIfSet("Display Pokemon Catch Rewards", "display_pokemon_catch_rewards", defaults.shouldDisplayPokemonCatchRewards, String::toBoolean),
+            shouldDisplayIfPokemonWasFromLure = getPropertyIfSet("Display If Pokemon Was Caught From Lure", "display_if_pokemon_from_lure", defaults.shouldDisplayPokemonCatchRewards, String::toBoolean),
 
             shouldLootPokestop = getPropertyIfSet("Loot Pokestops", "loot_pokestop", defaults.shouldLootPokestop, String::toBoolean),
             shouldCatchPokemons = getPropertyIfSet("Catch Pokemons", "catch_pokemon", defaults.shouldCatchPokemons, String::toBoolean),
@@ -193,6 +194,7 @@ data class Settings(
     val shouldDisplayPokestopName: Boolean = false,
     val shouldDisplayPokestopSpinRewards: Boolean = true,
     val shouldDisplayPokemonCatchRewards: Boolean = true,
+    val shouldDisplayIfPokemonWasFromLure: Boolean = true,
 
     val shouldLootPokestop: Boolean = true,
     var shouldCatchPokemons: Boolean = true,

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
@@ -11,6 +11,7 @@ package ink.abb.pogo.scraper.tasks
 import POGOProtos.Networking.Responses.CatchPokemonResponseOuterClass.CatchPokemonResponse
 import POGOProtos.Networking.Responses.EncounterResponseOuterClass
 import POGOProtos.Networking.Responses.EncounterResponseOuterClass.EncounterResponse.Status
+import com.pokegoapi.api.map.pokemon.encounter.DiskEncounterResult
 import com.pokegoapi.api.map.pokemon.encounter.NormalEncounterResult
 import ink.abb.pogo.scraper.Bot
 import ink.abb.pogo.scraper.Context
@@ -45,6 +46,7 @@ class CatchOneNearbyPokemon : Task {
             ctx.api.setLocation(ctx.lat.get(), ctx.lng.get(), 0.0)
 
             val encounterResult = catchablePokemon.encounterPokemon()
+            val wasFromLure = encounterResult is DiskEncounterResult
             if (encounterResult.wasSuccessful()) {
                 val pokemonData = encounterResult.pokemonData
                 Log.green("Encountered pokemon ${catchablePokemon.pokemonId} " +
@@ -78,10 +80,19 @@ class CatchOneNearbyPokemon : Task {
 
                 if (result.status == CatchPokemonResponse.CatchStatus.CATCH_SUCCESS) {
                     ctx.pokemonStats.first.andIncrement
+                    if (wasFromLure) {
+                        ctx.luredPokemonStats.andIncrement
+                    }
                     val iv = (pokemonData.individualAttack + pokemonData.individualDefense + pokemonData.individualStamina) * 100 / 45
                     var message = "Caught a ${catchablePokemon.pokemonId} " +
                             "with CP ${pokemonData.cp} and IV $iv%"
                     message += "\r\n ${pokemonData.getStatsFormatted()}"
+                    if (settings.shouldDisplayIfPokemonWasFromLure) {
+                        if (encounterResult is DiskEncounterResult)
+                            message += " (lured pokemon) "
+                        else
+                            message += " (wild pokemon) "
+                    }
                     if (settings.shouldDisplayPokemonCatchRewards)
                         message += ": [${result.xpList.sum()}x XP, ${result.candyList.sum()}x " +
                                 "Candy, ${result.stardustList.sum()}x Stardust]"

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/UpdateProfile.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/UpdateProfile.kt
@@ -36,6 +36,7 @@ class UpdateProfile : Task {
             Log.magenta("Profile update: ${player.stats.experience} XP on LVL ${player.stats.level}; $curLevelXP/$nextXP ($ratio%) to LVL ${player.stats.level + 1}")
             Log.magenta("XP gain: ${player.stats.experience - ctx.startXp.get()} XP; " +
                     "Pokemon caught/transferred: ${ctx.pokemonStats.first.get()}/${ctx.pokemonStats.second.get()}; " +
+                    "Pokemon caught from lures: ${ctx.luredPokemonStats.first.get()}; " +
                     "Items caught/dropped: ${ctx.itemStats.first.get()}/${ctx.itemStats.second.get()};\n" +
                     "Pokebank ${ctx.api.inventories.pokebank.pokemons.size + ctx.api.inventories.hatchery.eggs.size}/${ctx.profile.playerData.maxPokemonStorage}; " +
                     "Stardust ${ctx.profile.currencies[PlayerProfile.Currency.STARDUST]}; " +

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/UpdateProfile.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/UpdateProfile.kt
@@ -36,7 +36,7 @@ class UpdateProfile : Task {
             Log.magenta("Profile update: ${player.stats.experience} XP on LVL ${player.stats.level}; $curLevelXP/$nextXP ($ratio%) to LVL ${player.stats.level + 1}")
             Log.magenta("XP gain: ${player.stats.experience - ctx.startXp.get()} XP; " +
                     "Pokemon caught/transferred: ${ctx.pokemonStats.first.get()}/${ctx.pokemonStats.second.get()}; " +
-                    "Pokemon caught from lures: ${ctx.luredPokemonStats.first.get()}; " +
+                    "Pokemon caught from lures: ${ctx.luredPokemonStats.get()}; " +
                     "Items caught/dropped: ${ctx.itemStats.first.get()}/${ctx.itemStats.second.get()};\n" +
                     "Pokebank ${ctx.api.inventories.pokebank.pokemons.size + ctx.api.inventories.hatchery.eggs.size}/${ctx.profile.playerData.maxPokemonStorage}; " +
                     "Stardust ${ctx.profile.currencies[PlayerProfile.Currency.STARDUST]}; " +


### PR DESCRIPTION
**Changes made:**
* minor text changes...

but in all seriousness... 

For the webGUI branch (that has the lure stuff merged in) - I made it track how many pokemon were caught from lures as a separate stat. 

When a pokemon is caught, it will also log if it was from a lure or not (this is configurable)

