### PR TITLE
Update CSVWriter to work with Multibots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,6 @@ config.properties
 .DS_Store
 
 # exported file
-export.csv
+export_*.csv
 
 bot-settings/

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/Export.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/Export.kt
@@ -108,11 +108,11 @@ class Export : Task {
 
             when (settings.export) {
                 "CSV" -> {
-                    val writer = CSVWriter()
+                    val writer = CSVWriter("export_" + settings.name + ".csv")
                     writer.write(output)
                 }
                 "DSV" -> {
-                    val writer = CSVWriter(";")
+                    val writer = CSVWriter("export_" + settings.name + ".csv", ";")
                     writer.write(output)
                 }
                 else -> {

--- a/src/main/kotlin/ink/abb/pogo/scraper/util/io/CSVWriter.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/util/io/CSVWriter.kt
@@ -17,7 +17,7 @@ class CSVWriter(val delimiter: String = ",") {
     fun write(output: ArrayList<Array<String>>) {
         // UTF-8 with BOM to fix borked UTF-8 chars in MS Excel (for nickname output)
         // https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8
-        FileOutputStream("export.csv").use {
+        FileOutputStream("export_" + Thread.currentThread().name.replace(": ProfileLoop", "") + ".csv").use {
             it.write(239)
             it.write(187)
             it.write(191)

--- a/src/main/kotlin/ink/abb/pogo/scraper/util/io/CSVWriter.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/util/io/CSVWriter.kt
@@ -13,11 +13,11 @@ import java.io.OutputStreamWriter
 import java.io.PrintWriter
 import java.util.*
 
-class CSVWriter(val delimiter: String = ",") {
+class CSVWriter(val filename: String = "export.csv", val delimiter: String = ",") {
     fun write(output: ArrayList<Array<String>>) {
         // UTF-8 with BOM to fix borked UTF-8 chars in MS Excel (for nickname output)
         // https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8
-        FileOutputStream("export_" + Thread.currentThread().name.replace(": ProfileLoop", "") + ".csv").use {
+        FileOutputStream(filename).use {
             it.write(239)
             it.write(187)
             it.write(191)


### PR DESCRIPTION
**Fixed issue:** When running multiple accounts on the same bot, the same "export.csv" file was overwritten by each bot

**Changes made:**

* Write to export_botname.csv file when writing from Bot Main and ProfileLoop (also updated .gitignore with new filename format)

I'm not proud of the ": ProfileLoop" replace to fetch only the botname from the Thread, but I could not find a working AND proper way to do this :(