### PR TITLE
Make pokemon catchable again after transfer when inventory was full

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/Bot.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Bot.kt
@@ -48,7 +48,8 @@ class Bot(val api: PokemonGo, val settings: Settings) {
             AtomicInteger(0),
             Pair(AtomicInteger(0), AtomicInteger(0)),
             mutableSetOf(),
-            SocketServer()
+            SocketServer(),
+            Pair(AtomicBoolean(settings.catchPokemon), AtomicBoolean(false))
     )
 
     @Synchronized

--- a/src/main/kotlin/ink/abb/pogo/scraper/Context.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Context.kt
@@ -30,5 +30,7 @@ data class Context(
         val blacklistedEncounters: MutableSet<Long>,
         val server: SocketServer,
 
-        var walking: AtomicBoolean = AtomicBoolean(false)
+        var walking: AtomicBoolean = AtomicBoolean(false),
+        
+        var pokemonInventoryFullStatus: Pair<AtomicBoolean, AtomicBoolean>
 )

--- a/src/main/kotlin/ink/abb/pogo/scraper/Context.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Context.kt
@@ -29,8 +29,9 @@ data class Context(
 
         val blacklistedEncounters: MutableSet<Long>,
         val server: SocketServer,
-
-        var walking: AtomicBoolean = AtomicBoolean(false),
         
-        var pokemonInventoryFullStatus: Pair<AtomicBoolean, AtomicBoolean>
+        val pokemonInventoryFullStatus: Pair<AtomicBoolean, AtomicBoolean>,
+
+        var walking: AtomicBoolean = AtomicBoolean(false)
+        
 )

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
@@ -112,8 +112,8 @@ class CatchOneNearbyPokemon : Task {
                     Log.red("Disabling catching of Pokemon")
                     
                     // Save previous value for restore
-                    context.pokemonInventoryFullStatus.first = settings.catchPokemon 
-                    context.pokemonInventoryFullStatus.second = true
+                    ctx.pokemonInventoryFullStatus.first.set(settings.catchPokemon)
+                    ctx.pokemonInventoryFullStatus.second.set(true)
                     
                     settings.catchPokemon = false
                 }

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
@@ -110,6 +110,11 @@ class CatchOneNearbyPokemon : Task {
                 Log.red("Encounter failed with result: ${encounterResult.status}")
                 if (encounterResult.status == Status.POKEMON_INVENTORY_FULL) {
                     Log.red("Disabling catching of Pokemon")
+                    
+                    // Save previous value for restore
+                    context.pokemonInventoryFullStatus.first = settings.catchPokemon 
+                    context.pokemonInventoryFullStatus.second = true
+                    
                     settings.catchPokemon = false
                 }
             }

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
@@ -44,12 +44,12 @@ class ReleasePokemon : Task {
                                     "CP ${pokemon.cp} and IV $ivPercentage%; reason: $reason")
                             val result = pokemon.transferPokemon()
                             
-                            if(context.pokemonInventoryFull && !settings.catchPokemon) {
+                            if(ctx.pokemonInventoryFullStatus.second.get() && !settings.catchPokemon) {
                               // Just released a pokemon so the inventory is not full anymore
                               
                               // Restore previous value
-                              settings.catchPokemon = context.pokemonInventoryFullStatus.first
-                              context.pokemonInventoryFullStatus.second = false
+                              settings.catchPokemon = ctx.pokemonInventoryFullStatus.first.get()
+                              ctx.pokemonInventoryFullStatus.second.set(false)
                               
                               Log.green("Enabling catching of Pokemon")
                             }

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ReleasePokemon.kt
@@ -43,6 +43,17 @@ class ReleasePokemon : Task {
                             Log.yellow("Going to transfer ${pokemon.pokemonId.name} with " +
                                     "CP ${pokemon.cp} and IV $ivPercentage%; reason: $reason")
                             val result = pokemon.transferPokemon()
+                            
+                            if(context.pokemonInventoryFull && !settings.catchPokemon) {
+                              // Just released a pokemon so the inventory is not full anymore
+                              
+                              // Restore previous value
+                              settings.catchPokemon = context.pokemonInventoryFullStatus.first
+                              context.pokemonInventoryFullStatus.second = false
+                              
+                              Log.green("Enabling catching of Pokemon")
+                            }
+                            
                             if (result == Result.SUCCESS) {
                                 ctx.pokemonStats.second.andIncrement
                                 ctx.server.releasePokemon(pokemon.id)


### PR DESCRIPTION
I noticed that when the pokemon inventory is full, the bot set `settings.catchPokemon` to false.
And when a pokemon is released, the bot do nothing.

**Changes made:**

* Added a field in Context which store the default catchPokemon setting and the inventory status : `pokemonInventoryFullStatus`
* In CatchOneNearbyPokemon, populate `pokemonInventoryFullStatus` with current catchPokemon setting and inventory status before `settings.catchPokemon = false`
* In ReleasePokemon, restore `settings.catchPokemon` to saved value when a pokemon is released and inventory was full