### PR TITLE
added feature to transfer pokemon after maxCP ratio

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -124,6 +124,11 @@ transfer_iv_threshold=80
 # Minimum CP to keep a pokemon (to ignore CP: use -1)
 transfer_cp_threshold=400
 
+# Minimum CP % in relation to max CP of pokemon to your current trainer lvl to keep pokemon (to disable CP%:use -1)
+# e.g. Trainer lvl is 33, captured EEVEE has 490 CP which results in max possible CP of 984 with 15/14/15 IV
+# that however is below the threshold of 60% because its 49%
+transfer_cp_min_threshold=-1
+
 # List of pokemon you don't want to transfer regardless of CP
 # The names must be divided by a ","
 # If you want all pokemons to be transferred just leave it blank

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -94,6 +94,8 @@ class SettingsParser(val properties: Properties) {
 
                 transferCpThreshold = getPropertyIfSet("Minimum CP to keep a pokemon", "transfer_cp_threshold", defaults.transferCpThreshold, String::toInt),
 
+                transferCpMinThreshold = getPropertyIfSet("Minimum CP % in relation to max CP of pokemon to your current trainer lvl to keep pokemon", "transfer_cp_min_threshold", defaults.transferCpMinThreshold, String::toInt),
+
                 transferIvThreshold = getPropertyIfSet("Minimum IV percentage to keep a pokemon", "transfer_iv_threshold", defaults.transferIvThreshold, String::toInt),
 
                 ignoredPokemon = getPropertyIfSet("Never transfer these Pokemon", "ignored_pokemon", defaults.ignoredPokemon.map { it.name }.joinToString(","), String::toString).split(",").filter { it.isNotBlank() }.map { PokemonId.valueOf(it) },
@@ -206,6 +208,7 @@ data class Settings(
         val spawnRadius: Int = -1,
         val banSpinCount: Int = 0,
         val transferCpThreshold: Int = 400,
+        val transferCpMinThreshold: Int = -1,
         val transferIvThreshold: Int = 80,
         val ignoredPokemon: List<PokemonId> = listOf(PokemonId.EEVEE, PokemonId.MEWTWO, PokemonId.CHARMANDER),
 

--- a/src/main/kotlin/ink/abb/pogo/scraper/util/pokemon/PokemonData.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/util/pokemon/PokemonData.kt
@@ -22,6 +22,11 @@ fun PokemonData.getIvPercentage(): Int {
     return ivPercentage
 }
 
+fun PokemonData.getCpPercentageToPlayer(playerlvel: Int): Int {
+    // TODO replace this when api has implemented this see Pokemon.kt
+    return -1
+}
+
 fun PokemonData.getStatsFormatted(): String {
     val details = "Stamina: $individualStamina | Attack: $individualAttack | Defense: $individualDefense"
     return details + " | IV: ${getIv()} (${(getIvPercentage())}%)"

--- a/src/main/kotlin/ink/abb/pogo/scraper/util/pokemon/PokemonData.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/util/pokemon/PokemonData.kt
@@ -22,7 +22,7 @@ fun PokemonData.getIvPercentage(): Int {
     return ivPercentage
 }
 
-fun PokemonData.getCpPercentageToPlayer(playerlvel: Int): Int {
+fun PokemonData.getCpPercentageToPlayer(playerlevel: Int): Int {
     // TODO replace this when api has implemented this see Pokemon.kt
     return -1
 }


### PR DESCRIPTION
Added option to transfer pokemon with CpMax ratio
looks like this

`Going to transfer NIDORAN_FEMALE with CP 327 and IV 62%; reason: CP < 1500 and IV < 89% and CP max 704: achieved 46% <= 60%`

One use case would be like this:

```
transfer_cp_threshold=-1
transfer_iv_threshold=89 // whatever you like as IV
transfer_cp_min_threshold=60 
```
If that Nidoran had 600CP it would result in achieved CP% ~80% and would pass the filter. So no need to use CP anymore since with that you would always filter out a Magikarp which can have max ~260CP anyways if you set `transfer_cp_threshold` above 260. Which most of us did.

OR if you want to have the very best
```
transfer_cp_threshold=-1
transfer_iv_threshold=-1
transfer_cp_min_threshold=90
```
With that setting every Pokemon you catch must have almost a perfect IV and almost max possible CP for the current trainer lvl.