### PR TITLE
Groups the items that are kept by type so it keeps best of same type

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -62,6 +62,15 @@ item_lucky_egg=-1
 item_incense=-1
 item_lure_module=-1
 
+# Groups the items that are kept by type so it keeps best of same type
+# Ex: if you have item_revive=20 and item_max_revive=10 and set this
+#   to true, if you get 25 item_revive and 20 item_max_revive it will
+#   drop 15 item_revive and keep 10 item_revive and 20 item_max_revive
+# Items that have -1 are excluded from groups
+# Ex: if you set item_potion=-1 it will only group the other potions and
+#   ignore item_potion (never dropping item_potion)
+group_items_by_type=false
+
 ## Extra Info
 # Should the bot display rewards pokestop (true/false)
 display_pokestop_rewards=true

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -44,6 +44,7 @@ class SettingsParser(val properties: Properties) {
                 speed = getPropertyIfSet("Speed", "speed", defaults.speed, String::toDouble),
                 followStreets = getPropertyIfSet("Should the bot follow the streets (true) or just go directly to pokestops/waypoints", "follow_streets", defaults.followStreets, String::toBoolean),
                 dropItems = dropItems,
+                groupItemsByType = getPropertyIfSet("Should the items that are kept be grouped by type (keep best from same type)", "group_items_by_type", defaults.groupItemsByType, String::toBoolean),
 
                 uselessItems = mapOf(
                         Pair(ItemId.ITEM_REVIVE, getPropertyIfSet("Max number of items to keep from type ITEM_REVIVE", "item_revive", 20, String::toInt)),
@@ -160,6 +161,7 @@ data class Settings(
         val credentials: Credentials,
         val speed: Double = 2.8,
         val followStreets: Boolean = false,
+        val groupItemsByType : Boolean = false,
         val dropItems: Boolean = true,
         val uselessItems: Map<ItemId, Int> = mapOf(
                 Pair(ItemId.ITEM_REVIVE, 20),

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/DropUselessItems.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/DropUselessItems.kt
@@ -8,6 +8,7 @@
 
 package ink.abb.pogo.scraper.tasks
 
+import POGOProtos.Inventory.Item.ItemIdOuterClass.ItemId
 import POGOProtos.Networking.Responses.RecycleInventoryItemResponseOuterClass
 import ink.abb.pogo.scraper.Bot
 import ink.abb.pogo.scraper.Context
@@ -18,10 +19,74 @@ import ink.abb.pogo.scraper.util.cachedInventories
 
 class DropUselessItems : Task {
     override fun run(bot: Bot, ctx: Context, settings: Settings) {
-        settings.uselessItems.forEach {
+        // ignores the items that have -1
+        val itemsToDrop = settings.uselessItems.filter { it.value != -1 }
+        if (settings.groupItemsByType) dropGroupedItems(ctx, itemsToDrop) else dropItems(ctx, itemsToDrop)
+    }
+
+    /**
+     * Drops the excess items by group
+     */
+    fun dropGroupedItems(ctx: Context, items: Map<ItemId, Int>) {
+        // map with what items to keep in what amounts
+        val itemsToDrop = mutableMapOf<ItemId, Int>()
+        // adds not groupable items on map
+        itemsToDrop.putAll(items.filter { singlesFilter.contains(it.key) })
+        // groups items
+        val groupedItems = groupItems(items)
+        // adds new items to the map
+        groupedItems.forEach groupedItems@ {
+            var groupCount = 0
+            it.key.forEach { groupCount += ctx.api.cachedInventories.itemBag.getItem(it).count }
+            var neededToDrop = groupCount - it.value
+            if (neededToDrop > 0)
+                it.key.forEach {
+                    val item = ctx.api.cachedInventories.itemBag.getItem(it)
+                    if (neededToDrop <= item.count) {
+                        itemsToDrop.put(it, item.count - neededToDrop)
+                        return@groupedItems
+                    } else {
+                        neededToDrop -= item.count
+                        itemsToDrop.put(it, 0)
+                    }
+                }
+        }
+        // drops excess items
+        dropItems(ctx, itemsToDrop)
+    }
+
+    /**
+     * Groups the items using the groupFilters
+     * Each group contains the list of itemIds of the group and sum of all its number
+     */
+    fun groupItems(items: Map<ItemId, Int>): Map<Array<ItemId>, Int> {
+        val groupedItems = mutableMapOf<Array<ItemId>, Int>()
+        groupFilters.forEach {
+            val filter = it
+            val filteredItems = items.filter { filter.contains(it.key) }
+            groupedItems.put(filteredItems.keys.toTypedArray(), filteredItems.values.sum())
+        }
+        return groupedItems
+    }
+
+    // Items that can be grouped
+    val groupFilters = arrayOf(
+            arrayOf(ItemId.ITEM_REVIVE, ItemId.ITEM_MAX_REVIVE),
+            arrayOf(ItemId.ITEM_POTION, ItemId.ITEM_SUPER_POTION, ItemId.ITEM_HYPER_POTION, ItemId.ITEM_MAX_POTION),
+            arrayOf(ItemId.ITEM_POKE_BALL, ItemId.ITEM_GREAT_BALL, ItemId.ITEM_ULTRA_BALL, ItemId.ITEM_MASTER_BALL)
+    )
+
+    // Items that cant be grouped
+    val singlesFilter = arrayOf(ItemId.ITEM_RAZZ_BERRY, ItemId.ITEM_LUCKY_EGG, ItemId.ITEM_INCENSE_ORDINARY, ItemId.ITEM_TROY_DISK)
+
+    /**
+     * Drops the excess items by item
+     */
+    fun dropItems(ctx: Context, items: Map<ItemId, Int>) {
+        items.forEach {
             val item = ctx.api.cachedInventories.itemBag.getItem(it.key)
             val count = item.count - it.value
-            if (it.value != -1 && count > 0) {
+            if (count > 0) {
                 val result = ctx.api.cachedInventories.itemBag.removeItem(it.key, count)
                 if (result == RecycleInventoryItemResponseOuterClass.RecycleInventoryItemResponse.Result.SUCCESS) {
                     ctx.itemStats.second.getAndAdd(count)


### PR DESCRIPTION
**Fixed issue:** #480 #344

**Changes made:**

* Added `group_items_by_type` to config file with explanation
* Created `potion`, `revive` and `pokeball` group. (All the others are individual)
* If item has `-1` and is on a group, it will be excluded from the group and treated as individual. 

Now its possible to group the items by its type (predefined on code) and drop the lower tier items before the higher tier.

If for example you have set in total 150 in pokeballs (`item_poke_ball=40`, `item_great_ball=50`, `item_ultra_ball=50`, `item_master_ball=10`) and get 1 `item_great_ball`, it will first try to drop (if limit 150 reached) from `item_poke_ball` and only then from `item_great_ball`. So you can set all poke balls to 0 and `item_poke_ball=150` that will do exactly the same thing.

If for example you don't want a limit on `item_master_ball` and `item_ultra_ball` you can set both to `-1` and that way they will be excluded from the group.

This can be done on all the predefined groups (`potion`, `revive` and `pokeball`).

Log snippet:

> 10 ago 14:43:00 [default: BotLoop] - Looted pokestop "#####"; +50 XP: [1xITEM_POKE_BALL, 1xITEM_REVIVE, 1xITEM_ULTRA_BALL]
10 ago 14:43:04 [default: BotLoop] - Getting map of (##:########, ##:########)
10 ago 14:43:07 [default: ProfileLoop] - Profile update: 364019 XP on LVL 22; 29019/100000 (29,02%) to LVL 23
10 ago 14:43:07 [default: ProfileLoop] - XP gain: 5800 XP; Pokemon caught/transferred: 0/0; Pokemon caught from lures: 0; Items caught/dropped: 346/293;
Pokebank 246/250; Stardust 31293; Inventory 341/350
10 ago 14:43:09 [default: BotLoop] - Getting map of (##:########, ##:########)
10 ago 14:43:09 [default: BotLoop] - Dropped 1x ITEM_REVIVE
10 ago 14:43:10 [default: WalkingLoop] - Walking to (##:########, ##:########) in ##.###### steps.
10 ago 14:43:10 [default: BotLoop] - Dropped 2x ITEM_POKE_BALL
10 ago 14:43:14 [default: BotLoop] - Getting map of (##:########, ##:########)
