### PR TITLE
Feature: Thresholds

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -201,6 +201,12 @@ wait_chance=0.0
 wait_time_min=0
 wait_time_max=0
 
+# Maximum of times to loot Pokestops and catch Pokemon (24hr period):
+# Recommended pokestops threshold is 1500
+# Recommended pokemon threshold is 1000
+pokestop_threshold=1500
+pokemon_threshold=1000
+
 # List of pokemon names
 #MISSINGNO
 #BULBASAUR

--- a/src/main/kotlin/ink/abb/pogo/scraper/Context.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Context.kt
@@ -29,6 +29,9 @@ data class Context(
         val luredPokemonStats: AtomicInteger,
         val itemStats: Pair<AtomicInteger, AtomicInteger>,
 
+        val lootedPokestops: AtomicInteger,
+        val caughtPokemon: AtomicInteger,
+
         val blacklistedEncounters: MutableSet<Long>,
         val server: SocketServer,
 

--- a/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/Settings.kt
@@ -131,7 +131,11 @@ class SettingsParser(val properties: Properties) {
 
                 waitTimeMin = getPropertyIfSet("Minimal time to wait", "wait_time_min", defaults.waitTimeMin, String::toInt),
 
-                waitTimeMax = getPropertyIfSet("Maximal time to wait", "wait_time_max", defaults.waitTimeMax, String::toInt)
+                waitTimeMax = getPropertyIfSet("Maximal time to wait", "wait_time_max", defaults.waitTimeMax, String::toInt),
+
+                pokestopThreshold = getPropertyIfSet("The maximum amount of pokestops to loot before stopping", "pokestop_threshold", defaults.pokestopThreshold, String::toInt),
+
+                pokemonThreshold = getPropertyIfSet("The maximum amount of pokemon to catch before stopping", "pokemon_threshold", defaults.pokemonThreshold, String::toInt)
         )
     }
 
@@ -266,7 +270,10 @@ data class Settings(
 
         val waitChance: Double = 0.0,
         val waitTimeMin: Int = 0,
-        val waitTimeMax: Int = 0
+        val waitTimeMax: Int = 0,
+
+        val pokestopThreshold: Int = 1500,
+        val pokemonThreshold: Int = 1000
 ) {
     fun withName(name: String): Settings {
         this.name = name

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/CatchOneNearbyPokemon.kt
@@ -28,6 +28,13 @@ import ink.abb.pogo.scraper.util.pokemon.shouldTransfer
 class CatchOneNearbyPokemon : Task {
     override fun run(bot: Bot, ctx: Context, settings: Settings) {
         // STOP WALKING
+
+        if (ctx.caughtPokemon.get() > settings.pokemonThreshold) {
+            Thread.sleep(3600 * 12000)
+            ctx.caughtPokemon.set(0)
+            return
+        }
+
         ctx.pauseWalking.set(true)
         val pokemon = ctx.api.map.getCatchablePokemon(ctx.blacklistedEncounters)
 
@@ -96,6 +103,7 @@ class CatchOneNearbyPokemon : Task {
                 // TODO: temp fix for server timing issues regarding GetMapObjects
                 ctx.blacklistedEncounters.add(catchablePokemon.encounterId)
                 if (result.status == CatchPokemonResponse.CatchStatus.CATCH_SUCCESS) {
+                    ctx.caughtPokemon.andIncrement
                     ctx.pokemonStats.first.andIncrement
                     if (wasFromLure) {
                         ctx.luredPokemonStats.andIncrement

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/LootOneNearbyPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/LootOneNearbyPokestop.kt
@@ -26,6 +26,7 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
 
     override fun run(bot: Bot, ctx: Context, settings: Settings) {
         // STOP WALKING! until loot is done
+
         ctx.pauseWalking.set(true)
         ctx.api.setLocation(ctx.lat.get(), ctx.lng.get(), 0.0)
         val nearbyPokestops = sortedPokestops.filter {
@@ -60,6 +61,7 @@ class LootOneNearbyPokestop(val sortedPokestops: List<Pokestop>, val lootTimeout
 
             when (result.result) {
                 Result.SUCCESS -> {
+                    ctx.lootedPokestops.andIncrement
                     ctx.server.sendPokestop(closest)
                     ctx.server.sendProfile()
                     var message = "Looted pokestop $pokestopID; +${result.experience} XP"

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ProcessPokestops.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ProcessPokestops.kt
@@ -50,6 +50,11 @@ class ProcessPokestops(var pokestops: MutableCollection<Pokestop>) : Task {
         if (startPokestop == null)
             startPokestop = sortedPokestops.first()
 
+        if (ctx.lootedPokestops.get() > settings.pokestopThreshold) {
+            Thread.sleep(3600 * 12000)
+            ctx.lootedPokestops.set(0)
+        }
+
         if (settings.lootPokestop) {
             val loot = LootOneNearbyPokestop(sortedPokestops, lootTimeouts)
             try {

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/ProcessPokestops.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/ProcessPokestops.kt
@@ -53,6 +53,7 @@ class ProcessPokestops(var pokestops: MutableCollection<Pokestop>) : Task {
         if (ctx.lootedPokestops.get() > settings.pokestopThreshold) {
             Thread.sleep(3600 * 12000)
             ctx.lootedPokestops.set(0)
+            return
         }
 
         if (settings.lootPokestop) {


### PR DESCRIPTION
This pull request adds thresholds for a maximum amount of looted Pokestops and caught Pokemon. This will prevent the bot from continuously catching Pokemon and looting Pokestops, which normally leads to your account being flagged.

**Changes made:**

* Added a threshold for caught Pokemon and looted Pokestops
* Delay the tasks for 12 hours before resetting the threshold.
