### PR TITLE
Use disposable incubators for longest distance eggs

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/HatchEggs.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/HatchEggs.kt
@@ -38,7 +38,9 @@ class HatchEggs : Task {
         val incubators = ctx.api.cachedInventories.incubators
         val eggs = ctx.api.cachedInventories.hatchery.eggs
 
-        val freeIncubators = incubators.filter { !it.isInUse }
+        val freeIncubators = incubators
+                .filter { !it.isInUse }
+                .sortedByDescending { it.usesRemaining }
         val filteredEggs = eggs
                 .filter { !it.isIncubate }
                 .sortedByDescending { it.eggKmWalkedTarget }


### PR DESCRIPTION
**Changes made:**

* Sorting incubators by their uses remaining(so that the infinite one is last and is used for the shortest distance eggs)

