### PR TITLE
Fix radians mystery

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/controllers/BotController.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/controllers/BotController.kt
@@ -287,7 +287,7 @@ class BotController {
         val ctx: Context = service.getBotContext(name)
 
         if (!latitude.isNaN() && !longitude.isNaN()) {
-            ctx.server.coordinatesToGoTo.add(S2LatLng.fromRadians(latitude, longitude))
+            ctx.server.coordinatesToGoTo.add(S2LatLng.fromDegrees(latitude, longitude))
             return "SUCCESS"
         } else {
             return "FAIL"

--- a/src/main/kotlin/ink/abb/pogo/scraper/gui/SocketServer.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/gui/SocketServer.kt
@@ -52,8 +52,7 @@ class SocketServer {
         server?.addEventListener("goto", EventGoto::class.java) { client, data, ackRequest ->
             run {
                 if (data.lat != null && data.lng != null) {
-                    val coord = S2LatLng.fromRadians(data.lat!!, data.lng!!)
-                    coordinatesToGoTo.add(coord)
+                    coordinatesToGoTo.add(S2LatLng.fromDegrees(data.lat!!, data.lng!!))
                 }
             }
         }

--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/Walk.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/Walk.kt
@@ -32,9 +32,9 @@ class Walk(val sortedPokestops: List<Pokestop>, val lootTimeouts: Map<String, Lo
         if (ctx.server.coordinatesToGoTo.size > 0) {
             val coordinates = ctx.server.coordinatesToGoTo.first()
             ctx.server.coordinatesToGoTo.removeAt(0)
-            Log.normal("Walking to ${coordinates.latRadians()}, ${coordinates.lngRadians()}")
+            Log.normal("Walking to ${coordinates.latDegrees()}, ${coordinates.lngDegrees()}")
 
-            walk(bot, ctx, settings, S2LatLng.fromDegrees(coordinates.latRadians(), coordinates.lngRadians()), settings.speed, true)
+            walk(bot, ctx, settings, coordinates, settings.speed, true)
         } else {
             val nearestUnused: List<Pokestop> = sortedPokestops.filter {
                 val canLoot = it.canLoot(ignoreDistance = true, lootTimeouts = lootTimeouts, api = ctx.api)


### PR DESCRIPTION
**Fixed issue:** There was some mysterious "conversion" between S2LatLng degrees <-> radians in BotController/SocketServer/Walk Task.

The SocketServer/Botcontroller saved the lat/long (which are in fact in degrees) as radians and to "fix" it, the Walk task saved those "wrong" radians as degrees.

**Changes made:**

* Degrees for everyone!