### PR TITLE
Fix null pointer in WalkToStartPokestop

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToStartPokestop.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/tasks/WalkToStartPokestop.kt
@@ -8,6 +8,7 @@
 
 package ink.abb.pogo.scraper.tasks
 
+import com.google.maps.GeoApiContext
 import com.pokegoapi.api.map.fort.Pokestop
 import com.pokegoapi.google.common.geometry.S2LatLng
 import ink.abb.pogo.scraper.Bot
@@ -104,7 +105,7 @@ class WalkToStartPokestop(val startPokeStop: Pokestop) : Task {
             return
         }
         val timeout = 200L
-        val coordinatesList = getRouteCoordinates(ctx.lat.get(), ctx.lng.get(), startPokeStop.latitude, startPokeStop.longitude, settings, ctx.geoApiContext!!)
+        val coordinatesList = getRouteCoordinates(ctx.lat.get(), ctx.lng.get(), startPokeStop.latitude, startPokeStop.longitude, settings, ctx.geoApiContext ?: GeoApiContext())
         if (coordinatesList.size <= 0) {
             walk(bot, ctx, settings)
         } else {


### PR DESCRIPTION
**Fixed issue:**

```java
21 aug 15:36:21 [default: PokestopLoop] - Error running loop PokestopLoop!
kotlin.KotlinNullPointerException
        at ink.abb.pogo.scraper.tasks.WalkToStartPokestop.walkRoute(WalkToStartPokestop.kt:107)
        at ink.abb.pogo.scraper.tasks.WalkToStartPokestop.run(WalkToStartPokestop.kt:26)
        at ink.abb.pogo.scraper.Bot.task(Bot.kt:275)
        at ink.abb.pogo.scraper.Bot$start$5.invoke(Bot.kt:180)
        at ink.abb.pogo.scraper.Bot$start$5.invoke(Bot.kt:38)
        at ink.abb.pogo.scraper.Bot$runLoop$1.invoke(Bot.kt:216)
        at ink.abb.pogo.scraper.Bot$runLoop$1.invoke(Bot.kt:38)
        at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:18)

```

**Changes made:**

* Fixed the potential null pointer

