### PR TITLE
Fix gh-pages jenkins build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 	url = https://github.com/pureexe/Poppo
 [submodule "TTL55"]
 	path = TTL55
-	url = git://github.com/JoeyyT/PGBGUI
+	url = https://github.com/JoeyyT/PGBGUI


### PR DESCRIPTION
**Fixed issue:** gh-pages jenkins build broke

**Changes made:**

* Submodules need to be https:// instead of git:// or the jenkins build to the static delivery fails

