### PR TITLE
Fix REST API pokedex indexes

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/controllers/BotController.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/controllers/BotController.kt
@@ -357,7 +357,7 @@ class BotController {
         val pokedex = mutableListOf<PokedexEntry>()
         val api = service.getBotContext(name).api
 
-        for (i in 1..150) {
+        for (i in 0..151) {
             val entry: PokedexEntryOuterClass.PokedexEntry? = api.inventories.pokedex.getPokedexEntry(PokemonIdOuterClass.PokemonId.forNumber(i))
             entry ?: continue
 


### PR DESCRIPTION
**Fixed issue:** When requesting the pokedex via the REST API, missingno [0] and mew [151] would not be fetched

**Changes made:**

* Fixed the for loop start/end