### PR TITLE
Replace lateinit binding of dependencies with constructor-injection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ version '0.6.0'
 buildscript {
     ext {
         kotlin_version = '1.0.3'
-        springBootVersion = '1.3.6.RELEASE'
+        springBootVersion = '1.4.0.RELEASE'
         jacksonVersion = '2.8.0'
     }
 

--- a/src/main/kotlin/ink/abb/pogo/scraper/PokemonGoBotApplication.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/PokemonGoBotApplication.kt
@@ -26,9 +26,6 @@ import kotlin.concurrent.thread
 @SpringBootApplication
 open class PokemonGoBotApplication {
 
-    @Autowired
-    lateinit var authProvider: ApiAuthProvider
-
     @Bean
     open fun httpClient(): OkHttpClient {
         val builder = OkHttpClient.Builder()
@@ -50,7 +47,7 @@ open class PokemonGoBotApplication {
     }
 
     @Bean
-    open fun interceptorConfigurer(): WebMvcConfigurer {
+    open fun interceptorConfigurer(authProvider: ApiAuthProvider): WebMvcConfigurer {
         return object : WebMvcConfigurerAdapter() {
             override fun addInterceptors(registry: InterceptorRegistry) {
                 registry.addInterceptor(authProvider)
@@ -61,12 +58,8 @@ open class PokemonGoBotApplication {
     }
 
     @Component
-    open class BotRunner : CommandLineRunner {
-        @Autowired
-        lateinit var http: OkHttpClient
+    open class BotRunner(val http: OkHttpClient, val botRunService: BotService) : CommandLineRunner {
 
-        @Autowired
-        lateinit var botRunService: BotService
 
         override fun run(vararg args: String?) {
             val JSONConfigBotNames = botRunService.getJSONConfigBotNames()

--- a/src/main/kotlin/ink/abb/pogo/scraper/controllers/BotController.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/controllers/BotController.kt
@@ -32,13 +32,7 @@ import javax.servlet.http.HttpServletResponse
 @RestController
 @CrossOrigin
 @RequestMapping("/api")
-class BotController {
-
-    @Autowired
-    lateinit var service: BotService
-
-    @Autowired
-    lateinit var authProvider: ApiAuthProvider
+class BotController (val service: BotService, val authProvider: ApiAuthProvider) {
 
     @RequestMapping("/bots")
     fun bots(): List<Settings> {

--- a/src/main/kotlin/ink/abb/pogo/scraper/services/BotService.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/services/BotService.kt
@@ -22,10 +22,8 @@ import javax.annotation.PreDestroy
 import kotlin.concurrent.thread
 
 @Service
-class BotService {
+class BotService (val http: OkHttpClient) {
 
-    @Autowired
-    lateinit var http: OkHttpClient
 
     private val bots: MutableList<Bot> = mutableListOf()
     val settingsJSONWriter = SettingsJSONWriter()

--- a/src/main/kotlin/ink/abb/pogo/scraper/util/ApiAuthProvider.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/util/ApiAuthProvider.kt
@@ -19,10 +19,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 @Component
-open class ApiAuthProvider : HandlerInterceptorAdapter() {
-
-    @Autowired
-    lateinit var service: BotService
+open class ApiAuthProvider (val service: BotService) : HandlerInterceptorAdapter() {
 
     val random: SecureRandom = SecureRandom()
 


### PR DESCRIPTION
It is considered good practice in Spring applications to use
constructor injection whenever possible (the main reasons are better
readability and testability of classes).
Moreover, starting with 4.3.RC1 version of Spring, the @Autowired
annotation is no longer needed when a class has a single constructor.
Leveraging this fact along with Kotlin's very concise constructor
syntax yields some nice readability improvements